### PR TITLE
Initial commit for mbed-util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+yotta_modules/
+yotta_targets/
+build/
+.yotta.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# mbed system library
+# mbed utilities library
 
 Implementation of various generic data structures and algorithms used in mbed.

--- a/mbed-util/CriticalSectionLock.h
+++ b/mbed-util/CriticalSectionLock.h
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 ARM Limited. All rights reserved.
+
+#ifndef __MBED_UTIL_CRITICAL_SECTION_LOCK_H__
+#define __MBED_UTIL_CRITICAL_SECTION_LOCK_H__
+
+#include <stdint.h>
+#include "cmsis-core/core_generic.h"
+
+namespace mbed {
+namespace util {
+
+/** RAII object for disabling, then restoring, interrupt state
+  * Usage:
+  * @code
+  *
+  * void f() {
+  *     // some code here
+  *     {
+  *         CriticalSectionLock lock;
+  *         // Code in this block will run with interrupts disabled
+  *     }
+  *     // interrupts will be restored to their previous state
+  * }
+  * @endcode
+  */
+class CriticalSectionLock {
+public:
+    CriticalSectionLock() {
+        _state = __get_PRIMASK();
+        __disable_irq();
+    }
+
+    ~CriticalSectionLock() {
+        __set_PRIMASK(_state);
+    }
+
+private:
+    uint32_t _state;
+};
+
+} // namespace util
+} // namespace mbed
+
+#endif // #ifndef __MBED_UTIL_CRITICAL_SECTION_LOCK_H__
+

--- a/mbed-util/PoolAllocator.h
+++ b/mbed-util/PoolAllocator.h
@@ -1,0 +1,71 @@
+// Copyright (C) 2015 ARM Limited. All rights reserved.
+
+#ifndef __MBED_UTIL_POOL_ALLOCATOR_H__
+#define __MBED_UTIL_POOL_ALLOCATOR_H__
+
+#include <stddef.h>
+
+// [TODO] this should probably be 8, but at the moment our allocators are 
+// aligned at 4 bytes
+// [TODO] where should the system allocator alignment be defined?
+#define MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN       4
+
+namespace mbed {
+namespace util {
+
+/** A simple pool allocator class. It can allocate one elements oe 'element_size' bytes at a time.
+  * alloc() and free() operations are synchronized, they can be used safely from both user
+  * and interrupt context.
+  */
+class PoolAllocator {
+public:
+    /** Create a new pool allocator
+      * @param start pool start address
+      * @param elements the size of pool in elements (each of element_size bytes)
+      * @param element_size size of each pool element in bytes (this might be rounded up
+               to satisfy the 'alignment' argument)
+      * @param alignment allocation alignment in bytes
+      */
+    PoolAllocator(void *start, size_t elements, size_t element_size, unsigned alignment = MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN);
+
+    /** Allocate a new element from the pool
+     * @returns the address of the new element or NULL for error
+      */
+    void* alloc();
+
+    /** Allocate a new element from the pool and initialize it with 0
+      * @returns the address of the new element or NULL for error
+      */
+   void *calloc();
+
+    /** Free a previously allocated element
+      * @param p pointer to element
+      */
+    void free(void* p);
+
+    /** Returns a pool size suitable to hold the required number of elements
+      * @param elements the size of pool in elements (each of element_size bytes)
+      * @param element_size size of each pool element in bytes (this might be rounded up
+               to satisfy the 'alignment' argument)
+      * @param alignment allocation alignment in bytes
+      * @returns the size of the pool in bytes
+      */
+    static size_t get_pool_size(size_t elements, size_t element_size, unsigned alignment = MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN);
+
+    /** Check if this pool owns a pointer
+      * @param p the pointer to check
+      * @returns true if the pointer is inside this pool, false otherwise
+      */
+    bool owns(void *p) const;
+
+private:
+    void _init();
+
+    void *_start, *_free_block, *_end;
+    size_t _element_size;
+};
+
+} // namespace util
+} // namespace mbed
+
+#endif // #ifndef __MBED_UTIL_POOL_ALLOCATOR_H__

--- a/module.json
+++ b/module.json
@@ -1,0 +1,37 @@
+{
+  "name": "mbed-util",
+  "version": "0.0.0",
+  "description": "mbed utilities library",
+  "keywords": [],
+  "private": true,
+  "author": "Bogdan Marinescu <bogdan.marinescu@arm.com>",
+  "repository": {
+    "url": "git@github.com:ARMmbed/mbed-util.git",
+    "type": "git"
+  },
+  "homepage": "https://github.com/ARMmbed/mbed-util",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "targetDependencies": {
+    "mbed": {
+      "cmsis-core": "~0.2.1",
+      "mbed-alloc": "~0.0.4"
+    }
+  },
+  "testDependencies": {
+    "mbed-core": "~0.2.0"
+  },
+  "scripts": {
+    "testReporter": [
+      "mbedgt",
+      "--digest",
+      "stdin",
+      "-v",
+      "-V"
+    ]
+  }
+}

--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2015 ARM Limited. All rights reserved.
+
+#include "mbed-util/PoolAllocator.h"
+#include "cmsis-core/core_generic.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+namespace mbed {
+namespace util {
+
+PoolAllocator::PoolAllocator(void *start, size_t elements, size_t element_size, size_t alignment):
+    _start(start), _element_size(element_size) {
+    _element_size = (element_size + alignment - 1) & ~(alignment - 1);
+    _end = (void*)((uint8_t*)start + _element_size * elements);
+    _init();
+}
+
+void* PoolAllocator::alloc() {
+    void **free;
+
+    do {
+        if((free = (void**)__LDREXW((uint32_t*)&_free_block)) == NULL) {
+            __CLREX();
+            break;
+        }
+    } while(__STREXW((uint32_t)*free, (uint32_t*)&_free_block));
+    return (void*)free;
+}
+
+void PoolAllocator::free(void* p) {
+    if(owns(p)) {
+        do {
+            *((void**)p) = (void*)__LDREXW((uint32_t*)&_free_block);
+        } while(__STREXW((uint32_t)p, (uint32_t*)&_free_block));
+    }
+}
+
+bool PoolAllocator::owns(void *p) const {
+    return (p >= _start) && (p < _end);
+}
+
+size_t PoolAllocator::get_pool_size(size_t elements, size_t element_size, unsigned alignment) {
+    element_size = (element_size + alignment - 1) & ~(alignment - 1);
+    return element_size * elements;
+}
+
+void* PoolAllocator::calloc() {
+    uint32_t *blk = (uint32_t*)alloc();
+
+    if (NULL == blk)
+        return NULL;
+    for(unsigned i = 0; i < _element_size / 4; i ++, blk ++)
+        *blk = 0;
+    return blk;
+}
+
+void PoolAllocator::_init() {
+    _free_block = _start;
+
+    // Link all free blocks using offsets.
+    void* next;
+    void* blk = _free_block;
+
+    while(true) {
+        next = ((uint8_t *) blk) + _element_size;
+        if(next > _end)
+            break;
+        *((void **)blk) = next;
+        blk = next;
+    }
+    // count back one block and mark it as the last one
+    blk = ((uint8_t *) blk) - _element_size;
+    *((void **)blk) = 0;
+}
+
+} // namespace util
+} // namespace mbed
+


### PR DESCRIPTION
mbed-util is an utilies library for mbed, its job is to provide implementations
of various data structures and algorithms used in mbed. It is similar in scope to
https://github.com/ARMmbed/foundation (and will likely get some components from
there), but geared more towards mbed. It has a few advantages:
- some libraries can depend on mbed-util instead of mbed-core, which is a much
  more "lightweight" dependency
- it's not supposed to depend on mbed-core (see also the above point), which
  means that with the proper support code it should be usable on non-mbed
  platforms, for example POSIX based test environments

Initial components:
- critical section lock (implementation taken from https://github.com/ARMmbed/minar/blob/master/source/minar.cpp)
- pool allocator (implementation adapted from https://github.com/ARMmbed/system-pool)

Planned components:
- extendable pool allocator (soon to come)
- FunctionPointerX and Event (moved from mbed-core)
- generic data structures
- ...
