### PR TITLE
Provide an alternate implementation of Crit. Section for nRF5x

### DIFF
--- a/mbed-util/CriticalSectionLock.h
+++ b/mbed-util/CriticalSectionLock.h
@@ -45,7 +45,7 @@ public:
 #endif
     }
 
-public:
+private:
 #ifdef TARGET_NORDIC
     uint8_t  _state;
 #else


### PR DESCRIPTION
We've explored the possibility of using target dependencies, but yotta doesn't allow us to say:

```
if Nordic:
  take nrf-atomic-ops
else if M0:
  take M0-atomic-ops
else:
  take generic-atomic-ops
```

@bogdanm @0xc0170 @bremoran @autopulated 
