### PR TITLE
remove un-necessary include of core_generic.h from PoolAllocator.cpp

### DIFF
--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "mbed-util/PoolAllocator.h"
-#include "cmsis-core/core_generic.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
@0xc0170 @bogdanm 