### PR TITLE
Move IRQ state management into mbed-util

### DIFF
--- a/mbed-util/CriticalSectionLock.h
+++ b/mbed-util/CriticalSectionLock.h
@@ -20,9 +20,7 @@
 
 #include <stdint.h>
 #include "cmsis-core/core_generic.h"
-#ifdef TARGET_NORDIC
-#include "nrf_soc.h"
-#endif
+#include "mbed-util/irq_state.h"
 
 namespace mbed {
 namespace util {
@@ -44,32 +42,18 @@ namespace util {
 class CriticalSectionLock {
 public:
     CriticalSectionLock() {
-#ifdef TARGET_NORDIC
-        sd_nvic_critical_region_enter(&_state);
-#else
-        _state = __get_PRIMASK();
-        __disable_irq();
-#endif
+        _state = pushDisableIRQState();
     }
 
     ~CriticalSectionLock() {
-#ifdef TARGET_NORDIC
-        sd_nvic_critical_region_exit(_state);
-#else
-        __set_PRIMASK(_state);
-#endif
+        popDisableIRQState(_state);
     }
 
 private:
-#ifdef TARGET_NORDIC
-    uint8_t  _state;
-#else
-    uint32_t _state;
-#endif
+    irqstate_t _state;
 };
 
 } // namespace util
 } // namespace mbed
 
 #endif // #ifndef __MBED_UTIL_CRITICAL_SECTION_LOCK_H__
-

--- a/mbed-util/irq_state.h
+++ b/mbed-util/irq_state.h
@@ -26,6 +26,7 @@ namespace util {
 #ifdef TARGET_NORDIC
     typedef uint8_t  irqstate_t;
 #elif defined(TARGET_LIKE_POSIX)
+    #include <signal.h>
     typedef sigset_t irqstate_t;
 #else
     typedef uint32_t irqstate_t;

--- a/mbed-util/irq_state.h
+++ b/mbed-util/irq_state.h
@@ -1,0 +1,40 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MBED_UTIL_IRQ_STATE_H__
+#define __MBED_UTIL_IRQ_STATE_H__
+
+#include <stdint.h>
+
+namespace mbed {
+namespace util {
+
+#ifdef TARGET_NORDIC
+    typedef uint8_t  irqstate_t;
+#elif defined(TARGET_LIKE_POSIX)
+    typedef sigset_t irqstate_t;
+#else
+    typedef uint32_t irqstate_t;
+#endif
+/// @name IRQ State Management
+irqstate_t pushDisableIRQState();
+void popDisableIRQState(irqstate_t);
+
+} // namespace util
+} // namespace mbed
+
+#endif //__MBED_UTIL_IRQ_STATE_H__

--- a/source/irq_state.cpp
+++ b/source/irq_state.cpp
@@ -1,0 +1,76 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed-util/irq_state.h"
+
+#ifndef TARGET_LIKE_POSIX
+#include "cmsis-core/core_generic.h"
+#ifdef TARGET_NORDIC
+#include "nrf_soc.h"
+#endif /* #ifdef TARGET_NORDIC */
+#else  /* #ifdef TARGET_LIKE_POSIX */
+#include <assert.h>
+#include <unistd.h>
+#include <signal.h>
+#endif /* #ifdef TARGET_LIKE_POSIX */
+
+
+namespace mbed {
+namespace util {
+
+static uint32_t IRQNestingDepth = 0;
+
+irqstate_t pushDisableIRQState(){
+    irqstate_t ret;
+#ifdef TARGET_NORDIC
+    sd_nvic_critical_region_enter(&ret);
+#elif defined(TARGET_LIKE_POSIX)
+    int rc;
+    if (++IRQNestingDepth > 1) {
+        rc = sigprocmask(SIG_BLOCK, NULL, &ret);
+        assert(rc == 0);
+        return ret;
+    }
+
+    sigset_t fullSet;
+    rc = sigfillset(&fullSet);
+    assert(rc == 0);
+    rc = sigprocmask(SIG_BLOCK, &fullSet, &ret);
+    assert(rc == 0);
+#else
+        ret = __get_PRIMASK();
+        __disable_irq();
+#endif
+    return ret;
+}
+
+void popDisableIRQState(irqstate_t restore){
+#ifdef TARGET_NORDIC
+    sd_nvic_critical_region_exit(restore);
+#elif defined(TARGET_LIKE_POSIX)
+    assert(IRQNestingDepth > 0);
+    if (--IRQNestingDepth == 0) {
+        int rc = sigprocmask(SIG_SETMASK, &restore, NULL);
+        assert(rc == 0);
+    }
+#else
+    __set_PRIMASK(restore);
+#endif
+}
+
+} // namespace util
+} // namespace mbed


### PR DESCRIPTION
This should address the PR in https://github.com/ARMmbed/core-util/pull/23 is a more reusable way.  Now, minar should be able to use its IRQ disable/enable logic from this source.