### PR TITLE
Module - update cmsis and drivers minor versions

### DIFF
--- a/module.json
+++ b/module.json
@@ -20,7 +20,7 @@
   },
   "targetDependencies": {
     "mbed": {
-      "cmsis-core": "~0.2.2",
+      "cmsis-core": "~0.4.0",
       "mbed-drivers": ">=0.8.0"
     }
   },


### PR DESCRIPTION
cmsis-core already published

mbed-drivers will get 0.10.0 within hours, just need to +1 for this and will carry out updating drivers at the same time as core-util.