### PR TITLE
Fix EvenHandler and FunctionPointer warning

### DIFF
--- a/test/EventHandler/main.cpp
+++ b/test/EventHandler/main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "mbed.h"
+#include "test_env.h"
 #include "core-util/Event.h"
 #include <stdio.h>
 
@@ -349,6 +350,11 @@ static void test_event_assignment_and_swap() {
 
 void runTest(void)
 {
+    MBED_HOSTTEST_TIMEOUT(10);
+    MBED_HOSTTEST_SELECT(default_auto);
+    MBED_HOSTTEST_DESCRIPTION(EventHandler test);
+    MBED_HOSTTEST_START("EvenHandler_1");
+
     printf("========== Starting event handler test ==========\r\n");
     test_standalone_funcs();
     test_class_funcs_tca();
@@ -358,6 +364,7 @@ void runTest(void)
 
     printf ("Final MyArg instance count (should be 0): %d\r\n", MyArg::instcount);
     printf ("\r\nTest Complete\r\n");
+    MBED_HOSTTEST_RESULT(MyArg::instcount == 0);
 }
 
 void app_start(int, char* [])

--- a/test/FunctionPointer/main.cpp
+++ b/test/FunctionPointer/main.cpp
@@ -70,6 +70,6 @@ void runTest(void) {
     MBED_HOSTTEST_RESULT(true);
 }
 
-void app_start(int argc, char* argv[]) {
+void app_start(int, char*[]) {
     minar::Scheduler::postCallback(&runTest);
 }


### PR DESCRIPTION
Warning fix and EvenHandler to be compatible with greentea

Report with this fixes:
```
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| target        | platform_name | test                                   | result | elapsed_time (sec) | copy_method |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | core-util-test-sharedpointer           | OK     | 1.42               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-array                   | OK     | 1.4                | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | OK     | 1.44               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-functionpointer         | OK     | 1.38               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-poolallocator           | OK     | 1.4                | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-extendablepoolallocator | OK     | 1.44               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | OK     | 6.74               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-sbrk-mini               | OK     | 1.38               | shell       |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
```

@bogdanm @bremoran @rgrover