### PR TITLE
Replace bind with a version that uses const references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # mbed utilities library
 
 Implementation of various generic data structures and algorithms used in mbed.
+
+# Configuration
+Some parameters of the core-util library can be configured in yotta.  Currently, core-util supports configuring two things: the argument storage size of FunctionPointerBind and whether or not FunctionPointer checks its arguments before calling
+
+## Configuring the storage size for FunctionPointerBind's bound arguments
+In some cases it may be necessary to increase FunctionPointerBind's argument size.  In others, for memory optimization, it may be necessary to decrease the size of FunctionPointerBind's bound arguments.  If either of these are necessary, adding a new key with yotta config will allow this configuration: ```"util": {"functionPointer":{"arg-storage" : <bytes>}}```.
+
+## Configuring whether or not FunctionPointer checks its arguments before calling
+For debug purposes, it is possible to have FunctionPointer check its arguments before being called.   If it checks its arguments, it will use a ```CORE_UTIL_ASSERT```.  Checks can be disabled with: ```"util": {"functionPointer":{"disable-null-check" : true}}```

--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -169,7 +169,7 @@ public:
     }
 
     FunctionPointerBind<R> bind(const A1 &a1) {
-        FunctionPointerBind<R> fp;
+        FunctionPointerBind<R> fp(*this);
         void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp1_ops);
         new(storage) ArgStruct(a1);
         return fp;

--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -86,7 +86,8 @@ public:
 
     FunctionPointerBind<R> bind() {
         FunctionPointerBind<R> fp;
-        fp.bind(&FunctionPointerBase<R>::_nullops, (ArgStruct *) NULL, this);
+        void * storage = this->preBind(fp, (ArgStruct *)NULL, &FunctionPointerBase<R>::_nullops);
+        new(storage) ArgStruct();
         return fp;
     }
 
@@ -114,21 +115,20 @@ private:
     }
 };
 
+
 /* If we had variaditic templates, this wouldn't be a problem, but until C++11 is enabled, we are stuck with multiple classes... */
 
 /** A class for storing and calling a pointer to a static or member void function with one argument
  */
 template <typename R, typename A1>
 class FunctionPointer1 : public FunctionPointerBase<R> {
-protected:
+public:
     typedef struct arg_struct{
         A1 a1;
-        arg_struct(const A1 *b1) {
-            a1 = *b1;
+        arg_struct(const A1 &b1) {
+            a1 = b1;
         }
     } ArgStruct;
-
-public:
     typedef R(*static_fp)(A1);
     /** Create a FunctionPointer, attaching a static function
      *
@@ -172,7 +172,8 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1) {
         FunctionPointerBind<R> fp;
-        fp.bind(&_fp1_ops, (ArgStruct *) NULL, this, &a1);
+        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp1_ops);
+        new(storage) ArgStruct(a1);
         return fp;
     }
 
@@ -181,7 +182,7 @@ public:
      */
     R call(A1 a1)
     {
-        ArgStruct Args(&a1);
+        ArgStruct Args(a1);
         return FunctionPointerBase<R>::call(&Args);
     }
 
@@ -208,12 +209,9 @@ private:
         static_fp f = reinterpret_cast<static_fp>(object);
         return f(Args->a1);
     }
-    static void constructor(void * dest, va_list args) {
-        new(dest) ArgStruct(va_arg(args,A1*));
-    }
     static void copy_constructor(void *dest , void* src) {
         ArgStruct *src_args = static_cast<ArgStruct *>(src);
-        new(dest) ArgStruct(&(src_args->a1));
+        new(dest) ArgStruct(src_args->a1);
     }
     static void destructor(void *args) {
         ArgStruct *argstruct = static_cast<ArgStruct *>(args);
@@ -226,7 +224,6 @@ protected:
 
 template <typename R, typename A1>
 const struct FunctionPointerBase<R>::ArgOps FunctionPointer1<R,A1>::_fp1_ops = {
-    FunctionPointer1<R,A1>::constructor,
     FunctionPointer1<R,A1>::copy_constructor,
     FunctionPointer1<R,A1>::destructor
 };
@@ -236,17 +233,15 @@ const struct FunctionPointerBase<R>::ArgOps FunctionPointer1<R,A1>::_fp1_ops = {
  */
 template <typename R, typename A1, typename A2>
 class FunctionPointer2 : public FunctionPointerBase<R> {
-protected:
+public:
     typedef struct arg_struct{
         A1 a1;
         A2 a2;
-        arg_struct(const A1 *b1, const A2 *b2) {
-            a1 = *b1;
-            a2 = *b2;
+        arg_struct(const A1 &b1, const A2 &b2) {
+            a1 = b1;
+            a2 = b2;
         }
     } ArgStruct;
-
-public:
     typedef R(*static_fp)(A1, A2);
     /** Create a FunctionPointer, attaching a static function
      *
@@ -290,7 +285,8 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2) {
         FunctionPointerBind<R> fp;
-        fp.bind(&_fp2_ops, (ArgStruct *) NULL, this, &a1, &a2);
+        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp2_ops);
+        new(storage) ArgStruct(a1,a2);
         return fp;
     }
 
@@ -299,7 +295,7 @@ public:
      */
     R call(A1 a1, A2 a2)
     {
-        ArgStruct Args(&a1, &a2);
+        ArgStruct Args(a1, a2);
         return FunctionPointerBase<R>::call(&Args);
     }
 
@@ -326,14 +322,9 @@ private:
         static_fp f = reinterpret_cast<static_fp>(object);
         return f(Args->a1, Args->a2);
     }
-    static void constructor(void * dest, va_list args) {
-        A1 *a1 = va_arg(args, A1*);
-        A2 *a2 = va_arg(args, A2*);
-        new(dest) ArgStruct(a1, a2);
-    }
     static void copy_constructor(void *dest , void* src) {
         ArgStruct *src_args = static_cast<ArgStruct *>(src);
-        new(dest) ArgStruct(&(src_args->a1), &(src_args->a2));
+        new(dest) ArgStruct(src_args->a1, src_args->a2);
     }
     static void destructor(void *args) {
         ArgStruct *argstruct = static_cast<ArgStruct *>(args);
@@ -346,7 +337,6 @@ protected:
 
 template <typename R, typename A1, typename A2>
 const struct FunctionPointerBase<R>::ArgOps FunctionPointer2<R,A1,A2>::_fp2_ops = {
-    FunctionPointer2<R,A1,A2>::constructor,
     FunctionPointer2<R,A1,A2>::copy_constructor,
     FunctionPointer2<R,A1,A2>::destructor
 };
@@ -355,19 +345,17 @@ const struct FunctionPointerBase<R>::ArgOps FunctionPointer2<R,A1,A2>::_fp2_ops 
  */
 template <typename R, typename A1, typename A2, typename A3>
 class FunctionPointer3 : public FunctionPointerBase<R> {
-protected:
+public:
     typedef struct arg_struct{
         A1 a1;
         A2 a2;
         A3 a3;
-        arg_struct(const A1 *b1, const A2 *b2, const A3* b3) {
-            a1 = *b1;
-            a2 = *b2;
-            a3 = *b3;
+        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3) {
+            a1 = b1;
+            a2 = b2;
+            a3 = b3;
         }
     } ArgStruct;
-
-public:
     typedef R(*static_fp)(A1, A2, A3);
     /** Create a FunctionPointer, attaching a static function
      *
@@ -411,7 +399,8 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3) {
         FunctionPointerBind<R> fp;
-        fp.bind(&_fp3_ops, (ArgStruct *) NULL, this, &a1, &a2, &a3);
+        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp3_ops);
+        new(storage) ArgStruct(a1,a2,a3);
         return fp;
     }
 
@@ -420,7 +409,7 @@ public:
      */
     R call(A1 a1, A2 a2, A3 a3)
     {
-        ArgStruct Args(&a1, &a2, &a3);
+        ArgStruct Args(a1, a2, a3);
         return FunctionPointerBase<R>::call(&Args);
     }
 
@@ -447,15 +436,9 @@ private:
         static_fp f = reinterpret_cast<static_fp>(object);
         return f(Args->a1, Args->a2, Args->a3);
     }
-    static void constructor(void * dest, va_list args) {
-        A1 *a1 = va_arg(args, A1*);
-        A2 *a2 = va_arg(args, A2*);
-        A3 *a3 = va_arg(args, A3*);
-        new(dest) ArgStruct(a1, a2, a3);
-    }
     static void copy_constructor(void *dest , void* src) {
         ArgStruct *src_args = static_cast<ArgStruct *>(src);
-        new(dest) ArgStruct(&(src_args->a1), &(src_args->a2), &(src_args->a3));
+        new(dest) ArgStruct(src_args->a1, src_args->a2, src_args->a3);
     }
     static void destructor(void *args) {
         ArgStruct *argstruct = static_cast<ArgStruct *>(args);
@@ -468,7 +451,6 @@ protected:
 
 template <typename R, typename A1, typename A2, typename A3>
 const struct FunctionPointerBase<R>::ArgOps FunctionPointer3<R,A1,A2,A3>::_fp3_ops = {
-    FunctionPointer3<R,A1,A2,A3>::constructor,
     FunctionPointer3<R,A1,A2,A3>::copy_constructor,
     FunctionPointer3<R,A1,A2,A3>::destructor
 };
@@ -477,21 +459,19 @@ const struct FunctionPointerBase<R>::ArgOps FunctionPointer3<R,A1,A2,A3>::_fp3_o
  */
 template <typename R, typename A1, typename A2, typename A3, typename A4>
 class FunctionPointer4 : public FunctionPointerBase<R> {
-protected:
+public:
     typedef struct arg_struct{
         A1 a1;
         A2 a2;
         A3 a3;
         A4 a4;
-        arg_struct(const A1 *b1, const A2 *b2, const A3* b3, const A4* b4) {
-            a1 = *b1;
-            a2 = *b2;
-            a3 = *b3;
-            a4 = *b4;
+        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3, const A4 &b4) {
+            a1 = b1;
+            a2 = b2;
+            a3 = b3;
+            a4 = b4;
         }
     } ArgStruct;
-
-public:
     typedef R(*static_fp)(A1, A2, A3, A4);
     /** Create a FunctionPointer, attaching a static function
      *
@@ -535,7 +515,8 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3, const A4 &a4) {
         FunctionPointerBind<R> fp;
-        fp.bind(&_fp4_ops, (ArgStruct *) NULL, this, &a1, &a2, &a3, &a4);
+        void * storage = preBind(&fp, (ArgStruct *)NULL, &_fp4_ops);
+        new(storage) ArgStruct(a1,a2,a3,a4);
         return fp;
     }
 
@@ -544,7 +525,7 @@ public:
      */
     R call(A1 a1, A2 a2, A3 a3, A4 a4)
     {
-        ArgStruct Args(&a1, &a2, &a3, &a4);
+        ArgStruct Args(a1, a2, a3, a4);
         return FunctionPointerBase<R>::call(&Args);
     }
 
@@ -571,16 +552,9 @@ private:
         static_fp f = reinterpret_cast<static_fp>(object);
         return f(Args->a1, Args->a2, Args->a3, Args->a4);
     }
-    static void constructor(void * dest, va_list args) {
-        A1 *a1 = va_arg(args, A1*);
-        A2 *a2 = va_arg(args, A2*);
-        A3 *a3 = va_arg(args, A3*);
-        A4 *a4 = va_arg(args, A4*);
-        new(dest) ArgStruct(a1, a2, a3, a4);
-    }
     static void copy_constructor(void *dest , void* src) {
         ArgStruct *src_args = static_cast<ArgStruct *>(src);
-        new(dest) ArgStruct(&(src_args->a1), &(src_args->a2), &(src_args->a3), &(src_args->a4));
+        new(dest) ArgStruct(src_args->a1, src_args->a2, src_args->a3, src_args->a4);
     }
     static void destructor(void *args) {
         ArgStruct *argstruct = static_cast<ArgStruct *>(args);
@@ -593,7 +567,6 @@ protected:
 
 template <typename R, typename A1, typename A2, typename A3, typename A4>
 const struct FunctionPointerBase<R>::ArgOps FunctionPointer4<R,A1,A2,A3,A4>::_fp4_ops = {
-    FunctionPointer4<R,A1,A2,A3,A4>::constructor,
     FunctionPointer4<R,A1,A2,A3,A4>::copy_constructor,
     FunctionPointer4<R,A1,A2,A3,A4>::destructor
 };

--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -125,9 +125,7 @@ class FunctionPointer1 : public FunctionPointerBase<R> {
 public:
     typedef struct arg_struct{
         A1 a1;
-        arg_struct(const A1 &b1) {
-            a1 = b1;
-        }
+        arg_struct(const A1 &b1) : a1(b1){}
     } ArgStruct;
     typedef R(*static_fp)(A1);
     /** Create a FunctionPointer, attaching a static function
@@ -237,10 +235,7 @@ public:
     typedef struct arg_struct{
         A1 a1;
         A2 a2;
-        arg_struct(const A1 &b1, const A2 &b2) {
-            a1 = b1;
-            a2 = b2;
-        }
+        arg_struct(const A1 &b1, const A2 &b2) : a1(b1), a2(b2) {}
     } ArgStruct;
     typedef R(*static_fp)(A1, A2);
     /** Create a FunctionPointer, attaching a static function
@@ -350,11 +345,7 @@ public:
         A1 a1;
         A2 a2;
         A3 a3;
-        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3) {
-            a1 = b1;
-            a2 = b2;
-            a3 = b3;
-        }
+        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3) : a1(b1), a2(b2), a3(b3) {}
     } ArgStruct;
     typedef R(*static_fp)(A1, A2, A3);
     /** Create a FunctionPointer, attaching a static function
@@ -465,12 +456,8 @@ public:
         A2 a2;
         A3 a3;
         A4 a4;
-        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3, const A4 &b4) {
-            a1 = b1;
-            a2 = b2;
-            a3 = b3;
-            a4 = b4;
-        }
+        arg_struct(const A1 &b1, const A2 &b2, const A3 &b3, const A4 &b4) :
+            a1(b1), a2(b2), a3(b3), a4(b4) {}
     } ArgStruct;
     typedef R(*static_fp)(A1, A2, A3, A4);
     /** Create a FunctionPointer, attaching a static function
@@ -572,7 +559,6 @@ const struct FunctionPointerBase<R>::ArgOps FunctionPointer4<R,A1,A2,A3,A4>::_fp
 };
 
 typedef FunctionPointer0<void> FunctionPointer;
-//typedef FunctionPointer1<void, int> event_callback_t;
 
 } // namespace util
 } // namespace mbed

--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -89,7 +89,7 @@ public:
 
     FunctionPointerBind<R> bind() {
         FunctionPointerBind<R> fp(*this);
-        void * storage = this->preBind(fp, (ArgStruct *)NULL, &FunctionPointerBase<R>::_nullops);
+        void * storage = this->pre_bind(fp, (ArgStruct *)NULL, &FunctionPointerBase<R>::_nullops);
         new(storage) ArgStruct();
         return fp;
     }
@@ -170,7 +170,7 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1) {
         FunctionPointerBind<R> fp(*this);
-        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp1_ops);
+        void * storage = this->pre_bind(fp, (ArgStruct *)NULL, &_fp1_ops);
         new(storage) ArgStruct(a1);
         return fp;
     }
@@ -281,7 +281,7 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2) {
         FunctionPointerBind<R> fp(*this);
-        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp2_ops);
+        void * storage = this->pre_bind(fp, (ArgStruct *)NULL, &_fp2_ops);
         new(storage) ArgStruct(a1,a2);
         return fp;
     }
@@ -392,7 +392,7 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3) {
         FunctionPointerBind<R> fp(*this);
-        void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp3_ops);
+        void * storage = this->pre_bind(fp, (ArgStruct *)NULL, &_fp3_ops);
         new(storage) ArgStruct(a1,a2,a3);
         return fp;
     }
@@ -505,7 +505,7 @@ public:
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3, const A4 &a4) {
         FunctionPointerBind<R> fp(*this);
-        void * storage = preBind(&fp, (ArgStruct *)NULL, &_fp4_ops);
+        void * storage = this->pre_bind(&fp, (ArgStruct *)NULL, &_fp4_ops);
         new(storage) ArgStruct(a1,a2,a3,a4);
         return fp;
     }

--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -83,9 +83,12 @@ public:
     R call(){
         return FunctionPointerBase<R>::call(NULL);
     }
+    R operator ()(void) {
+        return FunctionPointerBase<R>::call(NULL);
+    }
 
     FunctionPointerBind<R> bind() {
-        FunctionPointerBind<R> fp;
+        FunctionPointerBind<R> fp(*this);
         void * storage = this->preBind(fp, (ArgStruct *)NULL, &FunctionPointerBase<R>::_nullops);
         new(storage) ArgStruct();
         return fp;
@@ -95,9 +98,6 @@ public:
         return reinterpret_cast<static_fp>(FunctionPointerBase<R>::_object);
     }
 
-    R operator ()(void) {
-        return call();
-    }
 
 private:
     template<typename T>
@@ -183,15 +183,16 @@ public:
         ArgStruct Args(a1);
         return FunctionPointerBase<R>::call(&Args);
     }
+    R operator ()(A1 a1) {
+        ArgStruct Args(a1);
+        return FunctionPointerBase<R>::call(&Args);
+    }
 
     static_fp get_function()const
     {
         return reinterpret_cast<static_fp>(FunctionPointerBase<R>::_object);
     }
 
-    R operator ()(A1 a) {
-        return call(a);
-    }
 
 private:
     template<typename T>
@@ -279,7 +280,7 @@ public:
     }
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2) {
-        FunctionPointerBind<R> fp;
+        FunctionPointerBind<R> fp(*this);
         void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp2_ops);
         new(storage) ArgStruct(a1,a2);
         return fp;
@@ -293,15 +294,16 @@ public:
         ArgStruct Args(a1, a2);
         return FunctionPointerBase<R>::call(&Args);
     }
+    R operator ()(A1 a1, A2 a2) {
+        ArgStruct Args(a1, a2);
+        return FunctionPointerBase<R>::call(&Args);
+    }
 
     static_fp get_function()const
     {
         return reinterpret_cast<static_fp>(FunctionPointerBase<R>::_object);
     }
 
-    R operator ()(A1 a1, A2 a2) {
-        return call(a1, a2);
-    }
 
 private:
     template<typename T>
@@ -389,7 +391,7 @@ public:
     }
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3) {
-        FunctionPointerBind<R> fp;
+        FunctionPointerBind<R> fp(*this);
         void * storage = this->preBind(fp, (ArgStruct *)NULL, &_fp3_ops);
         new(storage) ArgStruct(a1,a2,a3);
         return fp;
@@ -403,15 +405,16 @@ public:
         ArgStruct Args(a1, a2, a3);
         return FunctionPointerBase<R>::call(&Args);
     }
+    R operator ()(A1 a1, A2 a2, A3 a3) {
+        ArgStruct Args(a1, a2, a3);
+        return FunctionPointerBase<R>::call(&Args);
+    }
 
     static_fp get_function()const
     {
         return reinterpret_cast<static_fp>(FunctionPointerBase<R>::_object);
     }
 
-    R operator ()(A1 a1, A2 a2, A3 a3) {
-        return call(a1, a2, a3);
-    }
 
 private:
     template<typename T>
@@ -501,7 +504,7 @@ public:
     }
 
     FunctionPointerBind<R> bind(const A1 &a1, const A2 &a2, const A3 &a3, const A4 &a4) {
-        FunctionPointerBind<R> fp;
+        FunctionPointerBind<R> fp(*this);
         void * storage = preBind(&fp, (ArgStruct *)NULL, &_fp4_ops);
         new(storage) ArgStruct(a1,a2,a3,a4);
         return fp;
@@ -515,15 +518,16 @@ public:
         ArgStruct Args(a1, a2, a3, a4);
         return FunctionPointerBase<R>::call(&Args);
     }
+    R operator ()(A1 a1, A2 a2, A3 a3, A4 a4) {
+        ArgStruct Args(a1, a2, a3, a4);
+        return FunctionPointerBase<R>::call(&Args);
+    }
 
     static_fp get_function()const
     {
         return reinterpret_cast<static_fp>(FunctionPointerBase<R>::_object);
     }
 
-    R operator ()(A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call(a1, a2, a3, a4);
-    }
 
 private:
     template<typename T>

--- a/core-util/FunctionPointerBase.h
+++ b/core-util/FunctionPointerBase.h
@@ -98,7 +98,7 @@ protected:
     }
 
     template <typename S>
-    void * preBind(FunctionPointerBind<R> & fp, S * argStruct, const struct FunctionPointerBase<R>::ArgOps *ops)
+    void * pre_bind(FunctionPointerBind<R> & fp, S * argStruct, const struct FunctionPointerBase<R>::ArgOps *ops)
     {
         MBED_STATIC_ASSERT(sizeof(S) <= sizeof(fp._storage), ERROR: Arguments too large for FunctionPointerBind internal storage)
         (void) argStruct;

--- a/core-util/FunctionPointerBind.h
+++ b/core-util/FunctionPointerBind.h
@@ -54,6 +54,10 @@ public:
         _ops(&FunctionPointerBase<R>::_nullops)
     {}
 
+    FunctionPointerBind(const FunctionPointerBase<R> & fp) :
+        FunctionPointerBase<R>(fp)
+    {}
+
     FunctionPointerBind(const FunctionPointerBind<R> & fp):
         FunctionPointerBase<R>(),
         _ops(&FunctionPointerBase<R>::_nullops) {

--- a/core-util/FunctionPointerBind.h
+++ b/core-util/FunctionPointerBind.h
@@ -20,11 +20,13 @@
 #include <string.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <stdarg.h>
 #include <assert.h>
 #include "core-util/FunctionPointerBase.h"
 
-#ifndef EVENT_STORAGE_SIZE
+
+#ifdef YOTTA_CFG_UTIL_FUNCTIONPOINTER_ARG_STORAGE
+#define EVENT_STORAGE_SIZE (YOTTA_CFG_UTIL_FUNCTIONPOINTER_ARG_STORAGE)
+#else
 #define EVENT_STORAGE_SIZE 32
 #endif
 
@@ -36,8 +38,12 @@
 namespace mbed {
 namespace util {
 
+template <typename R>
+class FunctionPointerBase;
+
 template<typename R>
 class FunctionPointerBind : public FunctionPointerBase<R> {
+friend FunctionPointerBase<R>;
 public:
     // Call the Event
     inline R call() {
@@ -77,27 +83,6 @@ public:
         }
         _ops = &FunctionPointerBase<R>::_nullops;
         FunctionPointerBase<R>::clear();
-    }
-
-    template<typename S>
-    FunctionPointerBind<R> & bind(const struct FunctionPointerBase<R>::ArgOps * ops , S * argStruct, FunctionPointerBase<R> *fp, ...) {
-        MBED_STATIC_ASSERT(sizeof(S) <= sizeof(_storage), ERROR: Arguments too large for FunctionPointerBind internal storage)
-        if (_ops != &FunctionPointerBase<R>::_nullops) {
-            _ops->destructor(_storage);
-        }
-        _ops = ops;
-        FunctionPointerBase<R>::copy(fp);
-        assert(this->_ops != NULL);
-        assert(this->_ops->constructor != NULL);
-        if (argStruct) {
-            this->_ops->copy_args(this->_storage, (void *)argStruct);
-        } else {
-            va_list args;
-            va_start(args, fp);
-            this->_ops->constructor(_storage, args);
-            va_end(args);
-        }
-        return *this;
     }
 
     R operator()() {

--- a/test/FunctionPointer/int_types.cpp
+++ b/test/FunctionPointer/int_types.cpp
@@ -18,80 +18,80 @@
 #include "core-util/FunctionPointer.h"
 #include "int_types.hpp"
 
- bool called;
+bool called;
 
- void vsi(int i)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
- }
- void vspi(int *pi)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
- }
- void vsri(int& ri)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
- }
- void vsci(const int i)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
- }
- void vscpi(const int *pi)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
- }
- void vscri(const int& ri)
- {
-     called=true;
-     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
- }
+void vsi(int i)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
+}
+void vspi(int *pi)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
+}
+void vsri(int& ri)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
+}
+void vsci(const int i)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
+}
+void vscpi(const int *pi)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
+}
+void vscri(const int& ri)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
+}
 
- bool testInts(){
-     bool passed = true;
-     {
-         mbed::util::FunctionPointer1<void,int> fp_vsi(vsi);
-         called = false;
-         fp_vsi(1);
-         passed = called && passed;
-     }
-     {
-         mbed::util::FunctionPointer1<void,int *> fp_vspi(vspi);
-         called = false;
-         int i = 2;
-         fp_vspi(&i);
-         passed = called && passed;
-     }
-     {
-         mbed::util::FunctionPointer1<void,int &> fp_vsri(vsri);
-         called = false;
-         int i = 3;
-         fp_vsri(i);
-         passed = called && passed;
-     }
-     {
-         mbed::util::FunctionPointer1<void,const int> fp_vsci(vsci);
-         called = false;
-         fp_vsci(4);
-         passed = called && passed;
-     }
-     {
-         mbed::util::FunctionPointer1<void,const int *> fp_vscpi(vscpi);
-         called = false;
-         int i = 5;
-         fp_vscpi(&i);
-         passed = called && passed;
-     }
-     {
-         mbed::util::FunctionPointer1<void,const int &> fp_vscri(vscri);
-         called = false;
-         int i = 6;
-         fp_vscri(i);
-         passed = called && passed;
-     }
-     return passed;
- }
+bool testInts(){
+    bool passed = true;
+    {
+        mbed::util::FunctionPointer1<void,int> fp_vsi(vsi);
+        called = false;
+        fp_vsi(1);
+        passed = called && passed;
+    }
+    {
+        mbed::util::FunctionPointer1<void,int *> fp_vspi(vspi);
+        called = false;
+        int i = 2;
+        fp_vspi(&i);
+        passed = called && passed;
+    }
+    {
+        mbed::util::FunctionPointer1<void,int &> fp_vsri(vsri);
+        called = false;
+        int i = 3;
+        fp_vsri(i);
+        passed = called && passed;
+    }
+    {
+        mbed::util::FunctionPointer1<void,const int> fp_vsci(vsci);
+        called = false;
+        fp_vsci(4);
+        passed = called && passed;
+    }
+    {
+        mbed::util::FunctionPointer1<void,const int *> fp_vscpi(vscpi);
+        called = false;
+        int i = 5;
+        fp_vscpi(&i);
+        passed = called && passed;
+    }
+    {
+        mbed::util::FunctionPointer1<void,const int &> fp_vscri(vscri);
+        called = false;
+        int i = 6;
+        fp_vscri(i);
+        passed = called && passed;
+    }
+    return passed;
+}

--- a/test/FunctionPointer/int_types.cpp
+++ b/test/FunctionPointer/int_types.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include "core-util/FunctionPointer.h"
+#include "int_types.hpp"
+
+ bool called;
+
+ void vsi(int i)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
+ }
+ void vspi(int *pi)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
+ }
+ void vsri(int& ri)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
+ }
+ void vsci(const int i)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
+ }
+ void vscpi(const int *pi)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
+ }
+ void vscri(const int& ri)
+ {
+     called=true;
+     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
+ }
+
+ bool testInts(){
+     bool passed = true;
+     {
+         mbed::util::FunctionPointer1<void,int> fp_vsi(vsi);
+         called = false;
+         fp_vsi(1);
+         passed = called && passed;
+     }
+     {
+         mbed::util::FunctionPointer1<void,int *> fp_vspi(vspi);
+         called = false;
+         int i = 2;
+         fp_vspi(&i);
+         passed = called && passed;
+     }
+     {
+         mbed::util::FunctionPointer1<void,int &> fp_vsri(vsri);
+         called = false;
+         int i = 3;
+         fp_vsri(i);
+         passed = called && passed;
+     }
+     {
+         mbed::util::FunctionPointer1<void,const int> fp_vsci(vsci);
+         called = false;
+         fp_vsci(4);
+         passed = called && passed;
+     }
+     {
+         mbed::util::FunctionPointer1<void,const int *> fp_vscpi(vscpi);
+         called = false;
+         int i = 5;
+         fp_vscpi(&i);
+         passed = called && passed;
+     }
+     {
+         mbed::util::FunctionPointer1<void,const int &> fp_vscri(vscri);
+         called = false;
+         int i = 6;
+         fp_vscri(i);
+         passed = called && passed;
+     }
+     return passed;
+ }

--- a/test/FunctionPointer/int_types.cpp
+++ b/test/FunctionPointer/int_types.cpp
@@ -20,32 +20,32 @@
 
 bool called;
 
-void vsi(int i)
+static void vsi(int i)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
 }
-void vspi(int *pi)
+static void vspi(int *pi)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
 }
-void vsri(int& ri)
+static void vsri(int& ri)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
 }
-void vsci(const int i)
+static void vsci(const int i)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, i);
 }
-void vscpi(const int *pi)
+static void vscpi(const int *pi)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
 }
-void vscri(const int& ri)
+static void vscri(const int& ri)
 {
     called=true;
     printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);

--- a/test/FunctionPointer/int_types.hpp
+++ b/test/FunctionPointer/int_types.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #ifndef __CORE_UTIL_TEST_FUNCTIONPOINTER_INT_TYPES_H__
+ #define __CORE_UTIL_TEST_FUNCTIONPOINTER_INT_TYPES_H__
+
+bool testInts();
+
+ #endif // __CORE_UTIL_TEST_FUNCTIONPOINTER_INT_TYPES_H__

--- a/test/FunctionPointer/lifetime.cpp
+++ b/test/FunctionPointer/lifetime.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdio.h>
+#include "lifetime.hpp"
+#include "core-util/FunctionPointer.h"
+
+class LifetimeChecker {
+public:
+    LifetimeChecker(int arg) : _arg(arg) {
+        _activeInstances++;
+    }
+    LifetimeChecker(const LifetimeChecker & lc) : _arg(lc._arg) {
+        _cc = true;
+        _activeInstances++;
+    }
+    ~LifetimeChecker() {
+        _activeInstances--;
+    }
+    static int getInstances() {
+        return _activeInstances;
+    }
+    int getArg() {
+        return _arg;
+    }
+    static void reset() {
+        _wasCalled = false;
+        _ok = false;
+        _cc = false;
+    }
+    static bool wasCalled() {
+        return _wasCalled;
+    }
+    static bool isOk() {
+        return _ok;
+    }
+    static bool ccCalled() {
+        return _cc;
+    }
+    void set(bool ok) {
+        _wasCalled = true;
+        _ok = ok;
+    }
+protected:
+    int _arg;
+    static bool _wasCalled;
+    static bool _ok;
+    static bool _cc;
+    static int _activeInstances;
+};
+
+int LifetimeChecker::_activeInstances = 0;
+bool LifetimeChecker::_wasCalled;
+bool LifetimeChecker::_ok;
+bool LifetimeChecker::_cc;
+
+int lifeCheck(LifetimeChecker lc) {
+    int arg = lc.getArg();
+    int instances = lc.getInstances();
+    lc.set(instances == 4);
+    if (instances != 4) {
+        printf("Expected 4 instances, got %i\r\n",instances);
+    }
+    return arg-1;
+}
+int lifeCheckR(LifetimeChecker &lc) {
+    int arg = lc.getArg();
+    int instances = lc.getInstances();
+    lc.set(instances == 1);
+    if (instances != 1) {
+        printf("Expected 1 instances, got %i\r\n",instances);
+    }
+    return arg-2;
+}
+int lifeCheckP(LifetimeChecker *lc) {
+    int arg = lc->getArg();
+    int instances = lc->getInstances();
+    lc->set(instances == 1);
+    if (instances != 1) {
+        printf("Expected 1 instances, got %i\r\n",instances);
+    }
+    return arg-3;
+}
+
+
+bool checkLifetime() {
+    bool passed = true;
+    int rc;
+    {
+        LifetimeChecker::reset();
+        LifetimeChecker lc(1);
+        mbed::util::FunctionPointer1<int, LifetimeChecker> fp(lifeCheck);
+        if ((rc = fp(lc)) != 0) {
+            printf("call error: expected 0, got %i\n", rc);
+            passed = false;
+        }
+        printf("LifetimeChecker    : OK = %s, Was Called = %s, Copy Constructed = %s, Instances remaining: %d\r\n",
+            (lc.isOk()?"true":"false"), (lc.wasCalled()?"true":"false"), (lc.ccCalled()?"true":"false"), lc.getInstances());
+        passed = passed && lc.isOk() && lc.wasCalled() && lc.ccCalled() && (lc.getInstances() == 1);
+    }
+    {
+        LifetimeChecker::reset();
+        LifetimeChecker lc(2);
+        mbed::util::FunctionPointer1<int, LifetimeChecker&> fp(lifeCheckR);
+        if ((rc = fp(lc)) != 0) {
+            printf("call error: expected 0, got %i\n", rc);
+            passed = false;
+        }
+        printf("LifetimeChecker (R): OK = %s, Was Called = %s, Copy Constructed = %s, Instances remaining: %d\r\n",
+            (lc.isOk()?"true":"false"), (lc.wasCalled()?"true":"false"), (lc.ccCalled()?"true":"false"), lc.getInstances());
+        passed = passed && lc.isOk() && lc.wasCalled() && !lc.ccCalled() && (lc.getInstances() == 1);
+    }
+    {
+        LifetimeChecker::reset();
+        LifetimeChecker lc(3);
+        mbed::util::FunctionPointer1<int, LifetimeChecker*> fp(lifeCheckP);
+        if ((rc = fp(&lc)) != 0) {
+            printf("call error: expected 0, got %i\n", rc);
+            passed = false;
+        }
+        printf("LifetimeChecker (P): OK = %s, Was Called = %s, Copy Constructed = %s, Instances remaining: %d\r\n",
+            (lc.isOk()?"true":"false"), (lc.wasCalled()?"true":"false"), (lc.ccCalled()?"true":"false"), lc.getInstances());
+        passed = passed && lc.isOk() && lc.wasCalled() && !lc.ccCalled() && (lc.getInstances() == 1);
+    }
+    return passed;
+}

--- a/test/FunctionPointer/lifetime.cpp
+++ b/test/FunctionPointer/lifetime.cpp
@@ -29,6 +29,13 @@ public:
     ~LifetimeChecker() {
         _activeInstances--;
     }
+
+    LifetimeChecker& operator = (const LifetimeChecker & rhs) {
+        _cc = true;
+        _arg = rhs._arg;
+        return *this;
+    }
+
     static int getInstances() {
         return _activeInstances;
     }

--- a/test/FunctionPointer/lifetime.hpp
+++ b/test/FunctionPointer/lifetime.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #ifndef __CORE_UTIL_TEST_FUNCTIONPOINTER_LIFETIME_H__
+ #define __CORE_UTIL_TEST_FUNCTIONPOINTER_LIFETIME_H__
+
+bool checkLifetime();
+
+ #endif // __CORE_UTIL_TEST_FUNCTIONPOINTER_LIFETIME_H__

--- a/test/FunctionPointer/main.cpp
+++ b/test/FunctionPointer/main.cpp
@@ -70,8 +70,10 @@ void runTest(void) {
         result = result && ecp_flag;
         printf("ecp_flag = %d\r\n", ecp_flag);
     }
-    result = result && testInts();
-    result = result && checkLifetime();
+    bool iResult = testInts();
+    result = result && iResult;
+    bool lifeResult = checkLifetime();
+    result = result && lifeResult;
 
     printf("Test Complete\r\n");
     MBED_HOSTTEST_RESULT(result);

--- a/test/FunctionPointer/main.cpp
+++ b/test/FunctionPointer/main.cpp
@@ -17,8 +17,9 @@
 #include "mbed-drivers/mbed.h"
 #include "mbed-drivers/test_env.h"
 #include "core-util/FunctionPointer.h"
-#include "lifetime.hpp"
 #include "int_types.hpp"
+#include "lifetime.hpp"
+#include "side_effects.hpp"
 
 namespace {
 volatile int ebp_flag = 0;
@@ -73,6 +74,8 @@ void runTest(void) {
     bool iResult = testInts();
     result = result && iResult;
     bool lifeResult = checkLifetime();
+    result = result && lifeResult;
+    bool sideEffectResult = checkSideEffects();
     result = result && lifeResult;
 
     printf("Test Complete\r\n");

--- a/test/FunctionPointer/side_effects.cpp
+++ b/test/FunctionPointer/side_effects.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdio.h>
+#include "core-util/FunctionPointer.h"
+#include "side_effects.hpp"
+
+static bool called = false;
+
+static void vspi(int *pi)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, *pi);
+    *pi += 1;
+}
+static void vsri(int& ri)
+{
+    called=true;
+    printf("%s called with %i\r\n", __PRETTY_FUNCTION__, ri);
+    ri += 2;
+}
+
+
+bool checkSideEffects()
+{
+    bool passed = true;
+    {
+        mbed::util::FunctionPointer1<void,int *> fp_vspi(vspi);
+        called = false;
+        int i = 2;
+        fp_vspi(&i);
+        passed = called && passed && (i == 3);
+    }
+    {
+        mbed::util::FunctionPointer1<void,int &> fp_vsri(vsri);
+        called = false;
+        int i = 3;
+        fp_vsri(i);
+        passed = called && passed && (i == 5);
+    }
+    return passed;
+}

--- a/test/FunctionPointer/side_effects.hpp
+++ b/test/FunctionPointer/side_effects.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #ifndef __CORE_UTIL_TEST_FUNCTIONPOINTER_SIDE_EFFECTS_H__
+ #define __CORE_UTIL_TEST_FUNCTIONPOINTER_SIDE_EFFECTS_H__
+
+bool checkSideEffects();
+
+ #endif // __CORE_UTIL_TEST_FUNCTIONPOINTER_SIDE_EFFECTS_H__


### PR DESCRIPTION
This version of bind does away with stdarg and uses a friend class instead.  This allows FunctionPointer to work with all types of argument, including references.