### PR TITLE
Reduce FunctionPointerBase size and provide alignment guarantees for the storage of member function pointers

### DIFF
--- a/core-util/FunctionPointer.h
+++ b/core-util/FunctionPointer.h
@@ -100,13 +100,13 @@ public:
 
 private:
     template<typename T>
-    static R membercaller(void *object, uintptr_t *member, void *arg) {
+    static R membercaller(void *object, char *member, void *arg) {
         (void) arg;
         T* o = static_cast<T*>(object);
         R (T::**m)(void) = reinterpret_cast<R (T::**)(void)>(member);
         return (o->**m)();
     }
-    static R staticcaller(void *object, uintptr_t *member, void *arg) {
+    static R staticcaller(void *object, char *member, void *arg) {
         (void) arg;
         (void) member;
         static_fp f = reinterpret_cast<static_fp>(object);
@@ -196,13 +196,13 @@ public:
 
 private:
     template<typename T>
-    static R membercaller(void *object, uintptr_t *member, void *arg) {
+    static R membercaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         T* o = static_cast<T*>(object);
         R (T::**m)(A1) = reinterpret_cast<R (T::**)(A1)>(member);
         return (o->**m)(Args->a1);
     }
-    static R staticcaller(void *object, uintptr_t *member, void *arg) {
+    static R staticcaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         (void) member;
         static_fp f = reinterpret_cast<static_fp>(object);
@@ -314,13 +314,13 @@ public:
 
 private:
     template<typename T>
-    static R membercaller(void *object, uintptr_t *member, void *arg) {
+    static R membercaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         T* o = static_cast<T*>(object);
         R (T::**m)(A1, A2) = reinterpret_cast<R (T::**)(A1, A2)>(member);
         return (o->**m)(Args->a1, Args->a2);
     }
-    static R staticcaller(void *object, uintptr_t *member, void *arg) {
+    static R staticcaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         (void) member;
         static_fp f = reinterpret_cast<static_fp>(object);
@@ -435,13 +435,13 @@ public:
 
 private:
     template<typename T>
-    static R membercaller(void *object, uintptr_t *member, void *arg) {
+    static R membercaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         T* o = static_cast<T*>(object);
         R (T::**m)(A1, A2, A3) = reinterpret_cast<R (T::**)(A1, A2, A3)>(member);
         return (o->**m)(Args->a1, Args->a2, Args->a3);
     }
-    static R staticcaller(void *object, uintptr_t *member, void *arg) {
+    static R staticcaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         (void) member;
         static_fp f = reinterpret_cast<static_fp>(object);
@@ -559,13 +559,13 @@ public:
 
 private:
     template<typename T>
-    static R membercaller(void *object, uintptr_t *member, void *arg) {
+    static R membercaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         T* o = static_cast<T*>(object);
         R (T::**m)(A1, A2, A3, A4) = reinterpret_cast<R (T::**)(A1, A2, A3, A4)>(member);
         return (o->**m)(Args->a1, Args->a2, Args->a3, Args->a4);
     }
-    static R staticcaller(void *object, uintptr_t *member, void *arg) {
+    static R staticcaller(void *object, char *member, void *arg) {
         ArgStruct *Args = static_cast<ArgStruct *>(arg);
         (void) member;
         static_fp f = reinterpret_cast<static_fp>(object);

--- a/core-util/FunctionPointerBase.h
+++ b/core-util/FunctionPointerBase.h
@@ -52,19 +52,19 @@ protected:
         void (*destructor)(void *);
     };
 
-    // Forward declaration of anonymous class 
-    class AnonymousClass;
-    // Forward declaration of anonymous member function to this anonymous class
+    // Forward declaration of an unknown class 
+    class UnknownClass;
+    // Forward declaration of an unknown member function to this an unknown class
     // this kind of declaration is authorized by the standard (see 8.3.3/2 of C++ 03 standard).  
-    // As a result, the compiler will allocate for AnonymousFunctionMember_t the biggest size 
+    // As a result, the compiler will allocate for UnknownFunctionMember_t the biggest size 
     // and biggest alignment possible for member function. 
     // This type can be used inside unions, it will help to provide the storage 
     // with the proper size and alignment guarantees 
-    typedef void (AnonymousClass::*AnonymousFunctionMember_t)();
+    typedef void (UnknownClass::*UnknownFunctionMember_t)();
 
     union { 
-        char _member[sizeof(AnonymousFunctionMember_t)];
-        AnonymousFunctionMember_t _alignementAndSizeGuarantees;
+        char _member[sizeof(UnknownFunctionMember_t)];
+        UnknownFunctionMember_t _alignementAndSizeGuarantees;
     };
 
     void * _object; // object Pointer/function pointer

--- a/core-util/FunctionPointerBase.h
+++ b/core-util/FunctionPointerBase.h
@@ -32,11 +32,7 @@ public:
     }
 
     bool operator==(const FunctionPointerBase& other) const {
-        return ((_object == other._object) &&
-                (_member[0] == other._member[0]) &&
-                (_member[1] == other._member[1]) &&
-                (_member[2] == other._member[2]) &&
-                (_member[3] == other._member[3]));
+        return ((_object == other._object) && (memcmp(_member, other._member, sizeof(_member)) == 0));
     }
 
     /**
@@ -55,10 +51,24 @@ protected:
         void (*copy_args)(void *, void *);
         void (*destructor)(void *);
     };
+
+    // Forward declaration of anonymous class 
+    class AnonymousClass;
+    // Forward declaration of anonymous member function to this anonymous class
+    // this kind of declaration is authorized by the standard (see 8.3.3/2 of C++ 03 standard).  
+    // As a result, the compiler will allocate for AnonymousFunctionMember_t the biggest size 
+    // and biggest alignment possible for member function. 
+    // This type can be used inside unions, it will help to provide the storage 
+    // with the proper size and alignment guarantees 
+    typedef void (AnonymousClass::*AnonymousFunctionMember_t)();
+
+    union { 
+        char _member[sizeof(AnonymousFunctionMember_t)];
+        AnonymousFunctionMember_t _alignementAndSizeGuarantees;
+    };
+
     void * _object; // object Pointer/function pointer
-    R (*_membercaller)(void *, uintptr_t *, void *);
-    // aligned raw member function pointer storage - converted back by registered _membercaller
-    uintptr_t _member[4];
+    R (*_membercaller)(void *, char *, void *);
     static const struct ArgOps _nullops;
 
 protected:


### PR DESCRIPTION
This little change increase the size and alignment guarantees of the
storage space used in `FunctionPointerbase` to store member function
pointers.

As a side effect, it also reduce the size of the `FunctionPointerBase`
class from 28 bytes to 20.

It is important to note that it is still possible to decrease the size of `FunctionPointerBase`:
  * Get rid of virtual function in `FunctionPointerBase` (this change can save 4 bytes). It does not make sense to use virtual member functions just for the `clear` member function:
    - Does it have to be a polymorphic call ? 
    - I tried to track use cases of `FunctionPointerBase::clear` in a polymorphic way I didn't find any result in our sources, I would be glad if someone can provide me a use case.
    - Even if the clear function should be polymorphic, the interface is not correctly designed because overrides of `clear` should **always** call `FunctionPointerBase::clear`, a non virtual interface is much better in this case.
  * Exploit the fact that we run mbed os on ARM processors which use ARM ABI ... where member functions are well defined. This other change can save (I think) 4 bytes.