### PR TITLE
rename core-util.h to assert.h

### DIFF
--- a/core-util/assert.h
+++ b/core-util/assert.h
@@ -1,0 +1,54 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CORE_UTIL_ASSERT_H__
+#define __CORE_UTIL_ASSERT_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef NDEBUG
+#define CORE_UTIL_ASSERT(expr)              ((void)0)
+#define CORE_UTIL_ASSERT_MSG(expr, msg)     ((void)0)
+#else
+#define CORE_UTIL_ASSERT(expr)                           \
+do {                                                     \
+    if (!(expr)) {                                       \
+        core_util_assert_internal(#expr, __FILE__, __LINE__, NULL); \
+    }                                                    \
+} while (0)
+#define CORE_UTIL_ASSERT_MSG(expr, msg)                  \
+do {                                                     \
+    if (!(expr)) {                                       \
+        core_util_assert_internal(#expr, __FILE__, __LINE__, msg); \
+    }                                                    \
+} while (0)
+
+#endif
+
+#define CORE_UTIL_RUNTIME_ERROR(...)        core_util_runtime_error_internal(__FILE__, __LINE__, __VA_ARGS__)
+
+void core_util_runtime_error_internal(const char *fname, int line, const char* fmt, ...);
+void core_util_assert_internal(const char* expr, const char *fname, int line, const char *msg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef __CORE_UTIL_ASSERT_H__
+

--- a/core-util/core-util.h
+++ b/core-util/core-util.h
@@ -20,6 +20,7 @@
 
 // this file used to include the definitions now in assert.h, forward the
 // include for compatibility:
+#warning "core-util/core-util.h is deprecated: use core-util/assert.h instead"
 #include "./assert.h"
 
 #endif // ndef __CORE_UTIL_CORE_UTIL_H__

--- a/core-util/core-util.h
+++ b/core-util/core-util.h
@@ -15,40 +15,11 @@
  * limitations under the License.
  */
 
-#ifndef __CORE_UTIL_MBED_UTIL_H__
-#define __CORE_UTIL_MBED_UTIL_H__
+#ifndef __CORE_UTIL_CORE_UTIL_H__
+#define __CORE_UTIL_CORE_UTIL_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+// this file used to include the definitions now in assert.h, forward the
+// include for compatibility:
+#include "./assert.h"
 
-#ifdef NDEBUG
-#define CORE_UTIL_ASSERT(expr)              ((void)0)
-#define CORE_UTIL_ASSERT_MSG(expr, msg)     ((void)0)
-#else
-#define CORE_UTIL_ASSERT(expr)                           \
-do {                                                     \
-    if (!(expr)) {                                       \
-        core_util_assert_internal(#expr, __FILE__, __LINE__, NULL); \
-    }                                                    \
-} while (0)
-#define CORE_UTIL_ASSERT_MSG(expr, msg)                  \
-do {                                                     \
-    if (!(expr)) {                                       \
-        core_util_assert_internal(#expr, __FILE__, __LINE__, msg); \
-    }                                                    \
-} while (0)
-
-#endif
-
-#define CORE_UTIL_RUNTIME_ERROR(...)        core_util_runtime_error_internal(__FILE__, __LINE__, __VA_ARGS__)
-
-void core_util_runtime_error_internal(const char *fname, int line, const char* fmt, ...);
-void core_util_assert_internal(const char* expr, const char *fname, int line, const char *msg);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif // #ifndef __CORE_UTIL_MBED_UTIL_H__
-
+#endif // ndef __CORE_UTIL_CORE_UTIL_H__

--- a/source/assert_mbed.c
+++ b/source/assert_mbed.c
@@ -19,12 +19,13 @@
 
 #include <stdlib.h>
 #include <stdarg.h>
-#include "device.h"
-#include "mbed-drivers/mbed_interface.h"
-#include "core-util/core-util.h"
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif
+
+#include "device.h"
+#include "mbed-drivers/mbed_interface.h"
+#include "core-util/assert.h"
 
 void core_util_runtime_error_internal(const char *file, int line, const char* format, ...) {
 #if DEVICE_STDIO_MESSAGES

--- a/source/assert_mbed.c
+++ b/source/assert_mbed.c
@@ -17,13 +17,16 @@
 
 #ifdef TARGET_LIKE_MBED // only include this code for mbed targets
 
+// device.h header file defines whether we have files or not, so must come
+// first
+#include "device.h"
+
 #include <stdlib.h>
 #include <stdarg.h>
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif
 
-#include "device.h"
 #include "mbed-drivers/mbed_interface.h"
 #include "core-util/assert.h"
 

--- a/source/assert_posix.c
+++ b/source/assert_posix.c
@@ -21,6 +21,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#include "core-util/assert.h"
+
 void core_util_runtime_error_internal(const char *file, int line, const char* format, ...) {
     fprintf(stderr, "Runtime error in file %s, line %d: ", file, line);
     va_list arg;


### PR DESCRIPTION
(backwards compatible, but we should deprecate the confusingly named `core-util.h` which now forwards to `assert.h` in the future)

@bogdanm @bremoran 