### PR TITLE
Lambdas

### DIFF
--- a/core-util/v2/FunctionPointer.hpp
+++ b/core-util/v2/FunctionPointer.hpp
@@ -1,0 +1,101 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __FUNCTIONPOINTER_HPP__
+#define __FUNCTIONPOINTER_HPP__
+
+#include <string.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <new>
+#include <utility>
+#include <cstdio>
+
+namespace mbed {
+namespace util {
+
+template <typename FunctionType>
+class FunctionPointerInterface;
+
+class FunctionPointerStorage {
+public:
+    // Forward declaration of an unknown class
+    class UnknownClass;
+    // Forward declaration of an unknown member function to this an unknown class
+    // this kind of declaration is authorized by the standard (see 8.3.3/2 of C++ 03 standard).
+    // As a result, the compiler will allocate for UnknownFunctionMember_t the biggest size
+    // and biggest alignment possible for member function.
+    // This type can be used inside unions, it will help to provide the storage
+    // with the proper size and alignment guarantees
+    typedef void (UnknownClass::*UnknownFunctionMember_t)();
+
+    union {
+        void * _static_fp;
+        struct {
+            union {
+                char _member[sizeof(UnknownFunctionMember_t)];
+                UnknownFunctionMember_t _alignementAndSizeGuarantees;
+            };
+            void * _object;
+        } _method;
+        char _functor_storage[sizeof(UnknownFunctionMember_t) + sizeof(void *)];
+        void * _external_functor;
+    };
+};
+
+template <typename FunctionType>
+class FunctionPointerImpl : public FunctionPointerInterface<FunctionType> {
+public:
+    FunctionPointerStorage _fp;
+};
+
+template <typename FunctionType>
+class FPAlignmentAndSize;
+
+template<class T>
+T&& forward(typename std::remove_reference<T>::type& a) noexcept
+{
+    return static_cast<T&&>(a);
+}
+template<class T>
+T&& forward(typename std::remove_reference<T>::type&& a) noexcept
+{
+    return static_cast<T&&>(a);
+}
+
+template<typename FunctionType>
+class FunctionPointer;
+
+template<typename CallableType, size_t>
+class FunctionPointerBind;
+
+template<typename FunctionType>
+class StaticPointer;
+
+template<typename FunctionType, typename C>
+class MethodPointer;
+
+template<typename FunctionType, typename F>
+class FunctorPointer;
+
+
+
+#include "impl/FP0.hpp"
+#include "impl/FP1.hpp"
+} // namespace util
+} // namespace mbed
+
+#endif

--- a/core-util/v2/FunctionPointer.hpp
+++ b/core-util/v2/FunctionPointer.hpp
@@ -30,9 +30,8 @@ namespace util {
 
 
 namespace impl{
-template <typename FunctionType>
-class FunctionPointerInterface;
 
+template<size_t I = 0>
 class FunctionPointerStorage {
 public:
     // Forward declaration of an unknown class
@@ -46,7 +45,6 @@ public:
     typedef void (UnknownClass::*UnknownFunctionMember_t)();
 
     union {
-
         void * _static_fp;
         struct {
             union {
@@ -55,19 +53,24 @@ public:
             };
             void * _object;
         } _method;
-        char _functor_storage[sizeof(UnknownFunctionMember_t) + sizeof(void *)];
+        char _raw_storage[sizeof(void*) + sizeof(UnknownFunctionMember_t) + I];
         void * _external_functor;
     };
 };
 
+template<size_t I = 0>
 class FunctionPointerSize0 {
 public:
-    FunctionPointerStorage _fp;
+    FunctionPointerStorage<I> _fp;
     virtual void nullmethod()=0;
 };
-class FunctionPointerSize : public FunctionPointerSize0 {
+
+template<size_t I = 0>
+class FunctionPointerSize : public FunctionPointerSize0<I> {
 public:
     void nullmethod() {}
+    FunctionPointerSize(){}
+    FunctionPointerSize(const FunctionPointerSize &){}
 };
 template<class T>
 T&& forward(typename std::remove_reference<T>::type& a) noexcept
@@ -79,18 +82,23 @@ T&& forward(typename std::remove_reference<T>::type&& a) noexcept
 {
     return static_cast<T&&>(a);
 }
+template <typename FunctionType, size_t I = 0>
+class FunctionPointerInterface;
 
-template<typename FunctionType>
+template<typename FunctionType, size_t I = 0>
 class StaticPointer;
 
-template<typename FunctionType, typename C>
+template<typename FunctionType, typename C, size_t I = 0>
 class MethodPointer;
 
-template<typename FunctionType, typename F>
+template<typename FunctionType, typename F, size_t I = 0>
 class FunctorPointer;
 }
 
-template<typename FunctionType>
+template <typename OutputSignature, typename InputSignature, size_t I>
+class FPFunctor;
+
+template<typename FunctionType, size_t I = 0>
 class FunctionPointer;
 
 

--- a/core-util/v2/FunctionPointer.hpp
+++ b/core-util/v2/FunctionPointer.hpp
@@ -23,10 +23,13 @@
 #include <new>
 #include <utility>
 #include <cstdio>
+#include <type_traits>
 
 namespace mbed {
 namespace util {
 
+
+namespace impl{
 template <typename FunctionType>
 class FunctionPointerInterface;
 
@@ -43,6 +46,7 @@ public:
     typedef void (UnknownClass::*UnknownFunctionMember_t)();
 
     union {
+
         void * _static_fp;
         struct {
             union {
@@ -56,15 +60,15 @@ public:
     };
 };
 
-template <typename FunctionType>
-class FunctionPointerImpl : public FunctionPointerInterface<FunctionType> {
+class FunctionPointerSize0 {
 public:
     FunctionPointerStorage _fp;
+    virtual void nullmethod()=0;
 };
-
-template <typename FunctionType>
-class FPAlignmentAndSize;
-
+class FunctionPointerSize : public FunctionPointerSize0 {
+public:
+    void nullmethod() {}
+};
 template<class T>
 T&& forward(typename std::remove_reference<T>::type& a) noexcept
 {
@@ -77,12 +81,6 @@ T&& forward(typename std::remove_reference<T>::type&& a) noexcept
 }
 
 template<typename FunctionType>
-class FunctionPointer;
-
-template<typename CallableType, size_t>
-class FunctionPointerBind;
-
-template<typename FunctionType>
 class StaticPointer;
 
 template<typename FunctionType, typename C>
@@ -90,7 +88,10 @@ class MethodPointer;
 
 template<typename FunctionType, typename F>
 class FunctorPointer;
+}
 
+template<typename FunctionType>
+class FunctionPointer;
 
 
 #include "impl/FP0.hpp"

--- a/core-util/v2/impl/FP0.hpp
+++ b/core-util/v2/impl/FP0.hpp
@@ -1,0 +1,214 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __FUNCTIONPOINTER_IMPL_FP0_HPP__
+#define __FUNCTIONPOINTER_IMPL_FP0_HPP__
+#ifndef __FUNCTIONPOINTER_HPP__
+#error FP0.hpp is an internal file that should only be called from inside FunctionPointer.hpp
+#endif
+
+template <typename R>
+class FunctionPointerInterface<R()>{
+public:
+    virtual operator bool() const = 0;
+    virtual bool operator ==(const FunctionPointerInterface &) const = 0;
+    virtual FunctionPointerInterface & operator =(const FunctionPointerInterface &) = 0;
+    virtual R call(void) const = 0;
+    virtual ~FunctionPointerInterface(){};
+    virtual void copy_to(void *) const = 0;
+};
+template <typename R>
+class FPAlignmentAndSize<R()> : public FunctionPointerImpl<R()> {
+    operator bool() const {return false;}
+    bool operator ==(const FunctionPointerInterface<R()> & rhs) const { return false;}
+    FunctionPointerInterface<R()> & operator =(const FunctionPointerInterface<R()> &) { return *this; }
+    R call (void) const { return R();}
+    ~FPAlignmentAndSize() {}
+    void copy_to(void *target) const {
+        new(target) FPAlignmentAndSize(*this);
+    }
+};
+
+template<typename R>
+class FunctionPointer<R()> : FunctionPointerInterface<R()> {
+public:
+    typedef struct arg_struct{
+    } ArgStruct;
+    typedef R(*static_fp)(void);
+
+    FunctionPointer(R (*fp)()) {
+        new(_storage) StaticPointer<R()>(fp);
+    }
+    template <typename C>
+    FunctionPointer(C *c, R (C::*member)()) {
+        new(_storage) MethodPointer<R(), C>(c, member);
+    }
+    template <typename F>
+    FunctionPointer(const F & f) {
+        new(_storage) FunctorPointer<R(), F>(f);
+    }
+    operator bool() const {
+        return *reinterpret_cast<FunctionPointerImpl<R()> *>(&_storage);
+    }
+    bool operator ==(const FunctionPointerInterface<R()> & rhs) const {
+        return *reinterpret_cast<FunctionPointerImpl<R()> *>(&_storage) == rhs;
+    }
+    FunctionPointerInterface<R()> & operator=(const FunctionPointerInterface<R()> & rhs) {
+        reinterpret_cast<FunctionPointerImpl<R()>*>(_storage)->~FunctionPointerImpl<R()>();
+        rhs.copy_to(_storage);
+        return *this;
+    }
+    void copy_to(void *storage) const {
+        reinterpret_cast<FunctionPointerImpl<R()>*>(_storage)->copy_to(storage);
+    }
+    inline R operator ()() const {
+        return call();
+    }
+    R call() const {
+        return reinterpret_cast<FunctionPointerImpl<R()>*>(_storage)->call();
+    }
+    ~FunctionPointer() {
+        reinterpret_cast<FunctionPointerImpl<R()>*>(_storage)->~FunctionPointerImpl<R()>();
+    }
+protected:
+    union {
+        char _storage[sizeof(FPAlignmentAndSize<R()>)];
+        FPAlignmentAndSize<R()> _alignementAndSizeGuarantees;
+    };
+};
+
+/** A class for storing and calling a pointer to a static or member void function without arguments
+ */
+template<typename R>
+class StaticPointer<R()> : public FunctionPointerImpl<R()>{
+public:
+    StaticPointer(R (*function)() = 0)
+    {
+        attach(function);
+    }
+    StaticPointer(const StaticPointer& fp) {
+        *this = fp;
+    }
+    void attach(R (*function)()) {
+        this->_fp._static_fp = (void*)function;
+    }
+    R call() const{
+        return reinterpret_cast<R (*)()>(this->_fp._static_fp)();
+    }
+    R (*get_function() const)() {
+        return this->_fp._static_fp;
+    }
+    operator bool() const {
+        return (this->_fp._static_fp != NULL);
+    }
+    bool operator==(const FunctionPointerInterface<R()> & rhs) const {
+        return (this->_fp._static_fp == static_cast<const StaticPointer *>(&rhs)->_fp._static_fp);
+    }
+    FunctionPointerInterface<R()> & operator = (const FunctionPointerInterface<R()> & rhs) {
+        return *this = static_cast<const StaticPointer &>(rhs);
+    }
+    StaticPointer & operator = (const StaticPointer & rhs) {
+        this->_fp._static_fp = rhs._fp._static_fp;
+        return *this;
+    }
+    void copy_to(void * storage) const {
+        new(storage) StaticPointer(*this);
+    }
+};
+
+template<typename R, typename C>
+class MethodPointer<R(), C> : public FunctionPointerImpl<R()>{
+public:
+    MethodPointer(C *object, R (C::*member)(void))
+    {
+        attach(object, member);
+    }
+    MethodPointer(const MethodPointer& fp) {
+        *this = fp;
+    }
+    void attach(C *object, R (C::*member)(void)) {
+        this->_fp._method._object = (void *) object;
+        *reinterpret_cast<R (C::**)(void)>(this->_fp._method._member) = member;
+    }
+    R call() const{
+        C* o = static_cast<C*>(this->_fp._method._object);
+        R (C::**m)(void) = reinterpret_cast<R (C::**)(void)>(const_cast<char *>(this->_fp._method._member));
+        return (o->**m)();
+    }
+    R (*get_function() const)(){
+        return NULL;
+    }
+    operator bool() const {
+        return (this->_fp._method._object != NULL);
+    }
+    bool operator ==(const FunctionPointerInterface<R()> & rhs) const {
+        return (this->_fp._method._object == static_cast<const MethodPointer *>(&rhs)->_fp._method._object) &&
+            (0 == memcmp(this->_fp._method._member, static_cast<const MethodPointer *>(&rhs)->_fp._method._member, sizeof(this->_fp._method._member)));
+    }
+    MethodPointer & operator = (const MethodPointer & rhs) {
+        this->_fp._method._object = rhs._fp._method._object;
+        memcpy(this->_fp._method._member, rhs._fp._method._member, sizeof(this->_fp._method._member));
+        return *this;
+    }
+    FunctionPointerInterface<R()> & operator = (const FunctionPointerInterface<R()> & rhs) {
+        return *this = *static_cast<const MethodPointer *>(&rhs);
+    }
+    void copy_to(void * storage) const {
+        new(storage) MethodPointer(*this);
+    }
+};
+
+template<typename R, typename F>
+class FunctorPointer<R(), F> : public FunctionPointerImpl<R()>{
+public:
+    FunctorPointer(const F & f)
+    {
+        attach(f);
+    }
+    FunctorPointer(const FunctorPointer & fp) {
+        *this = fp;
+    }
+    void attach(const F & f) {
+        new(this->_fp._functor_storage)F(f);
+    }
+    R call() const{
+        return reinterpret_cast<const F &>(this->_fp._functor_storage)();
+    }
+    R (*get_function() const)(){
+        return NULL;
+    }
+    operator bool() const {
+        return (bool)reinterpret_cast<const F &>(this->_fp._functor_storage);
+    }
+    bool operator ==(const FunctionPointerInterface<R()> & rhs) const {
+        return (reinterpret_cast<const F &>(this->_fp._functor_storage) ==
+                reinterpret_cast<const F &>(static_cast<const FunctorPointer &>(rhs)._fp._functor_storage));
+    }
+    FunctionPointerInterface<R()> & operator = (const FunctionPointerInterface<R()> & rhs) {
+        return *this = *static_cast<const FunctorPointer *>(&rhs);
+    }
+    FunctorPointer & operator = (const FunctorPointer & rhs) {
+        new(this->_fp._functor_storage) F(reinterpret_cast<const F &>(rhs._fp._functor_storage));
+        return *this;
+    }
+
+    void copy_to(void * storage) const {
+        new(storage) FunctorPointer(*this);
+    }
+    ~FunctorPointer() {
+        reinterpret_cast<F*>(this->_fp._functor_storage)->~F();
+    }
+};
+#endif

--- a/core-util/v2/impl/FP1.hpp
+++ b/core-util/v2/impl/FP1.hpp
@@ -1,0 +1,209 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __FUNCTIONPOINTER_IMPL_FP1_HPP__
+#define __FUNCTIONPOINTER_IMPL_FP1_HPP__
+#ifndef __FUNCTIONPOINTER_HPP__
+#error FP1.hpp is an internal file that should only be called from inside FunctionPointer.hpp
+#endif
+
+template <typename R, typename A1>
+class FunctionPointerInterface<R(A1)> : protected FunctionPointerStorage {
+public:
+    virtual operator bool() const = 0;
+    virtual bool operator ==(const FunctionPointerInterface &) const = 0;
+    virtual FunctionPointerInterface & operator =(const FunctionPointerInterface &) = 0;
+    virtual R call(A1&&) const = 0;
+    virtual ~FunctionPointerInterface(){};
+protected:
+    virtual void copy_to(void *) const = 0;
+};
+
+template <typename R, typename A1>
+class FPAlignmentAndSize<R(A1)> : public FunctionPointerImpl<R(A1)> {
+    operator bool() const {return false;}
+    bool operator ==(const FunctionPointerInterface<R(A1)> & rhs) const { return false;}
+    FunctionPointerInterface<R(A1)> & operator =(const FunctionPointerInterface<R(A1)> &) { return *this; }
+    R call (A1&&) const { return R();}
+    ~FPAlignmentAndSize() {}
+protected:
+    void copy_to(void *target) const {
+        new(target) FPAlignmentAndSize(*this);
+    }
+};
+
+
+template <typename R, typename A1>
+class FunctionPointer<R(A1)> {
+public:
+    typedef struct arg_struct{
+    } ArgStruct;
+    typedef R(*static_fp)(A1);
+    FunctionPointer(R (*fp)(A1)) {
+        new(_storage) StaticPointer<R(A1)>(fp);
+    }
+    template <typename C>
+    FunctionPointer(C *c, R (C::*member)(A1)) {
+        new(_storage) MethodPointer<R(A1), C>(c, member);
+    }
+    template <typename F>
+    FunctionPointer(const F & f) {
+        new(_storage) FunctorPointer<R(A1), F>(f);
+    }
+    operator bool() const {
+        return *reinterpret_cast<FunctionPointerImpl<R(A1)> *>(const_cast<char *>(_storage));
+    }
+    bool operator ==(const FunctionPointerInterface<R(A1)> & rhs) const {
+        return *reinterpret_cast<FunctionPointerImpl<R(A1)> *>(const_cast<char *>(_storage)) == rhs;
+    }
+    inline R operator ()(A1&& a1) const {
+        return call(forward<A1&&>(a1));
+    }
+    R call(A1&& a1) const {
+        return reinterpret_cast<FunctionPointerImpl<R(A1)>*>(_storage)->call(forward<A1&&>(a1));
+    }
+    ~FunctionPointer() {
+        reinterpret_cast<FunctionPointerImpl<R(A1)>*>(_storage)->~FunctionPointerImpl<R(A1)>();
+    }
+protected:
+    union {
+        char _storage[sizeof(FPAlignmentAndSize<R(A1)>)];
+        FPAlignmentAndSize<R(A1)> _alignementAndSizeGuarantees;
+    };
+};
+
+/** A class for storing and calling a pointer to a static or member void function without arguments
+ */
+template <typename R, typename A1>
+class StaticPointer<R(A1)> : public FunctionPointerImpl<R(A1)>{
+public:
+    StaticPointer(R (*function)(A1) = 0)
+    {
+        attach(function);
+    }
+    StaticPointer(const StaticPointer& fp) {
+        *this = fp;
+    }
+    void attach(R (*function)(A1)) {
+        this->_fp._static_fp = (void*)function;
+    }
+    R call(A1&& a1) const{
+        R (*f)(A1) = reinterpret_cast<R (*)(A1)>(this->_fp._static_fp);
+        return f(forward<A1>(a1));
+    }
+    R (*get_function() const)(A1) {
+        return this->_fp._static_fp;
+    }
+    operator bool() const {
+        return (this->_fp._static_fp != NULL);
+    }
+    bool operator==(const FunctionPointerInterface<R(A1)> & rhs) const {
+        return (this->_fp._static_fp == static_cast<const StaticPointer *>(&rhs)->_fp._static_fp);
+    }
+    FunctionPointerInterface<R(A1)> & operator = (const FunctionPointerInterface<R(A1)> & rhs) {
+        return *this = static_cast<const StaticPointer &>(rhs);
+    }
+    StaticPointer & operator = (const StaticPointer & rhs) {
+        this->_fp._static_fp = rhs._fp._static_fp;
+        return *this;
+    }
+    void copy_to(void * storage) const {
+        new(storage) StaticPointer(*this);
+    }
+};
+
+template<typename R, typename A1, typename C>
+class MethodPointer<R(A1), C> : public FunctionPointerImpl<R(A1)>{
+public:
+    MethodPointer(C *object, R (C::*member)(A1))
+    {
+        attach(object, member);
+    }
+    MethodPointer(const MethodPointer& fp) {
+        MethodPointer::operator=(fp);
+    }
+    void attach(C *object, R (C::*member)(A1)) {
+        this->_fp._method._object = (void *) object;
+        *reinterpret_cast<R (C::**)(A1)>(this->_fp._method._member) = member;
+    }
+    R call(A1&& a1) const{
+        C* o = static_cast<C*>(this->_fp._method._object);
+        R (C::**m)(A1) = reinterpret_cast<R (C::**)(A1)>(const_cast<char *>(this->_fp._method._member));
+        return (o->**m)(forward<A1>(a1));
+    }
+    R (*get_function() const)(){
+        return NULL;
+    }
+    operator bool() const {
+        return (this->_fp._method._object != NULL);
+    }
+    bool operator ==(const FunctionPointerInterface<R(A1)> & rhs) const {
+        return (this->_fp._method._object == static_cast<const MethodPointer *>(&rhs)->_method._object) &&
+            (0 == memcmp(this->_fp._method._member, static_cast<const MethodPointer *>(&rhs)->_method._member, sizeof(this->_fp._method._member)));
+    }
+    MethodPointer & operator = (const MethodPointer & rhs) {
+        this->_fp._method._object = rhs._fp._method._object;
+        memcpy(this->_fp._method._member, rhs._fp._method._member, sizeof(this->_fp._method._member));
+        return *this;
+    }
+    FunctionPointerInterface<R(A1)> & operator = (const FunctionPointerInterface<R(A1)> & rhs) {
+        return *this = *static_cast<const MethodPointer *>(&rhs);
+    }
+    void copy_to(void * storage) const {
+        new(storage) MethodPointer(*this);
+    }
+};
+
+template<typename R, typename A1, typename F>
+class FunctorPointer<R(A1), F> : public FunctionPointerImpl<R(A1)>{
+public:
+    FunctorPointer(const F & f)
+    {
+        attach(f);
+    }
+    FunctorPointer(const FunctorPointer & fp) {
+        *this = fp;
+    }
+    void attach(const F & f) {
+        new(this->_fp._functor_storage)F(f);
+    }
+    R call(A1&& a1) const{
+        return reinterpret_cast<const F &>(this->_fp._functor_storage)(forward<A1>(a1));
+    }
+    R (*get_function() const)(){
+        return NULL;
+    }
+    operator bool() const {
+        return (bool)reinterpret_cast<const F &>(this->_fp._functor_storage);
+    }
+    bool operator ==(const FunctionPointerInterface<R(A1)> & rhs) const {
+        return (reinterpret_cast<const F &>(this->_fp._functor_storage) ==
+                reinterpret_cast<const F &>(static_cast<const FunctorPointer *>(&rhs)->_fp._functor_storage));
+    }
+    FunctionPointerInterface<R(A1)> & operator = (const FunctionPointerInterface<R(A1)> & rhs) {
+        return *this = *static_cast<const FunctorPointer *>(&rhs);
+    }
+    FunctorPointer & operator = (const FunctorPointer & rhs) {
+        new(this->_fp._functor_storage) F(reinterpret_cast<const F &>(rhs._fp._functor_storage));
+        return *this;
+    }
+    void copy_to(void * storage) const {
+        new(storage) FunctorPointer(*this);
+    }
+    ~FunctorPointer() {
+        reinterpret_cast<F*>(this->_fp._functor_storage)->~F();
+    }
+};
+#endif


### PR DESCRIPTION
This PR enables the use of Functors in general and lambdas in specific. It also reduces function call overhead and builds ```FunctionPointer``` in a much more C++ way--using C++ vtables instead of membercaller and the ops structure, which are effectively vtables.

Note that a FunctionPointer to a large functor will induce a malloc. Further copies of said function pointer will cause additional mallocs.

Reducing function call overhead has required some C++11 features: mostly, ```std::forward```.  

This PR needs to be upgraded with variadic macros. To make that happen the FPFunctor storage needs to be replaced with a ```std::tuple```.

This is full of template metaprogramming, such as ```std::enable_if``` and ```std::is_same``` some of these could be implemented in other ways if necessary.  This approach provides a low run-time overhead.

This implementation has been built to use a minimal number of stack frames. Only two are used for most function calls. Bound function pointers require an additional two stack frames. (4 in total).  This is a penalty which is associated with pass-by-value function pointer objects. It could easily be mitigated by function pointer references to pool-allocated function-pointer objects. This would replace one stack frame with an object dereference. I do not expect there to be significant runtime overhead in the additional stack frames; it simply makes debugging less pleasant.

This implementation has been built to use a minimal number of copies of an object. It should only create a single duplicate of any pass-by-value object, which is the expected overhead for a normal function call. It creates two copies for bound function pointers. One copy is stored in the bound arguments; one copy is created when passed to the bound function.

cc @hugovincent @bogdanm @autopulated @0xc0170 @rgrover @niklas-arm @pan-