### PR TITLE
minor improvements

### DIFF
--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -75,7 +75,7 @@ public:
       * @param p the pointer to check
       * @returns true if the pointer is inside this pool, false otherwise
       */
-    bool owns(void *p) const;
+    bool owns(const void *p) const;
 
     /** Aligns a quantity up to the given alignment (which must be a power of 2)
       * @param n the quantity to align

--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -25,9 +25,8 @@
 namespace mbed {
 namespace util {
 
-PoolAllocator::PoolAllocator(void *start, size_t elements, size_t element_size, size_t alignment):
-    _start(start), _element_size(element_size) {
-    _element_size = align_up(element_size, alignment);
+PoolAllocator::PoolAllocator(void *start, size_t elements, size_t element_size, unsigned alignment):
+    _start(start), _element_size(align_up(element_size, alignment)) {
     _end = (void*)((uint8_t*)start + _element_size * elements);
     _init();
 }

--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -45,8 +45,9 @@ void* PoolAllocator::alloc() {
 
 void PoolAllocator::free(void* p) {
     if (owns(p)) {
-        uintptr_t prev_free = reinterpret_cast<uintptr_t>(_free_block);
         while (true) {
+            uintptr_t prev_free = reinterpret_cast<uintptr_t>(_free_block);
+
             *((void**)p) = (void*)prev_free;
             if (atomic_cas((uintptr_t*)&_free_block, &prev_free, (uintptr_t)p)) {
                 break;

--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -56,7 +56,7 @@ void PoolAllocator::free(void* p) {
     }
 }
 
-bool PoolAllocator::owns(void *p) const {
+bool PoolAllocator::owns(const void *p) const {
     return (p >= _start) && (p < _end);
 }
 

--- a/source/PoolAllocator.cpp
+++ b/source/PoolAllocator.cpp
@@ -32,12 +32,12 @@ PoolAllocator::PoolAllocator(void *start, size_t elements, size_t element_size, 
 }
 
 void* PoolAllocator::alloc() {
-    uint32_t prev_free = (uint32_t)_free_block;
+    uintptr_t prev_free = reinterpret_cast<uintptr_t>(_free_block);
     if (0 == prev_free)
         return NULL;
     while (true) {
         void **const new_free = (void **)(*((void **)prev_free));
-        if (atomic_cas((uint32_t*)&_free_block, &prev_free, (uint32_t)new_free)) {
+        if (atomic_cas((uintptr_t*)&_free_block, &prev_free, (uintptr_t)new_free)) {
             return (void*)prev_free;
         }
     }
@@ -45,10 +45,10 @@ void* PoolAllocator::alloc() {
 
 void PoolAllocator::free(void* p) {
     if (owns(p)) {
-        uint32_t prev_free = (uint32_t)_free_block;
+        uintptr_t prev_free = reinterpret_cast<uintptr_t>(_free_block);
         while (true) {
             *((void**)p) = (void*)prev_free;
-            if (atomic_cas((uint32_t*)&_free_block, &prev_free, (uint32_t)p)) {
+            if (atomic_cas((uintptr_t*)&_free_block, &prev_free, (uintptr_t)p)) {
                 break;
             }
         }


### PR DESCRIPTION
@0xc0170 @bogdanm 

I ran GreenTea against mbed-drivers using frdm-k64f-gcc. Here are the results:

mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
	detected 'K64F' -> 'K64F[0]', console at '/dev/ttyACM1', mounted at '/media/rgrover/MBED2', target id '0240022652f86e0a000000000000000000000000af2193b2'
mbedgt: yotta search for mbed-target 'k64f'
	calling yotta: yotta --plain search -k mbed-target:k64f target
	found target 'frdm-k64f-gcc'
	found target 'frdm-k64f-armcc'
mbedgt: processing 'frdm-k64f-gcc' yotta target compatible platforms...
mbedgt: processing 'K64F' platform...
mbedgt: using platform 'K64F' for test:
	target_id_mbed_htm = '0240022652f86e0a000000000000000000000000af2193b2'
	mount_point = '/media/rgrover/MBED2'
	target_id = '0240022652f86e0a000000000000000000000000af2193b2'
	serial_port = '/dev/ttyACM1'
	target_id_usb_id = '0240022652f86e0a000000000000000000000000af2193b2'
	platform_name = 'K64F'
	platform_name_unique = 'K64F[0]'
mbedgt: building your sources and tests with yotta...
	calling yotta: yotta --target=frdm-k64f-gcc,* build
info: generate for target: frdm-k64f-gcc 1.0.1 at /home/rgrover/play/yotta-modules/mbed-drivers/yotta_targets/frdm-k64f-gcc
GCC version is: 4.9.3
-- Configuring done
-- Generating done
-- Build files have been written to: /home/rgrover/play/yotta-modules/mbed-drivers/build/frdm-k64f-gcc
ninja: no work to do.
mbedgt: yotta build for target 'frdm-k64f-gcc' was successful
mbedgt: running 20 tests for target 'frdm-k64f-gcc' and platform 'K64F'
	use 1 instance for testing
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-serial_interrupt' .............................................. OK in 4.13 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-blinky' ........................................................ OK in 5.24 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-div' ........................................................... OK in 1.41 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-cstring' ....................................................... FAIL in 1.55 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-stdio' ......................................................... OK in 0.64 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-stl' ........................................................... OK in 1.72 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-rtc' ........................................................... OK in 4.51 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-dev_null' ...................................................... OK in 3.31 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-cpp' ........................................................... OK in 1.46 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-timeout' ....................................................... OK in 11.45 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-basic' ......................................................... OK in 1.24 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-ticker' ........................................................ OK in 11.26 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-ticker_2' ...................................................... OK in 11.28 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-heap_and_stack' ................................................ OK in 1.46 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-echo' .......................................................... OK in 4.21 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-hello' ......................................................... OK in 0.29 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-time_us' ....................................................... OK in 11.26 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-sleep_timeout' ................................................. OK in 3.26 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-ticker_3' ...................................................... OK in 11.30 sec
mbedgt: test on hardware with target id: 0240022652f86e0a000000000000000000000000af2193b2 
	test 'mbed-drivers-test-detect' ........................................................ OK in 0.36 sec
mbedgt: test report:
+---------------+---------------+------------------------------------+--------+--------------------+-------------+
| target        | platform_name | test                               | result | elapsed_time (sec) | copy_method |
+---------------+---------------+------------------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-serial_interrupt | OK     | 4.13               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-blinky           | OK     | 5.24               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-div              | OK     | 1.41               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-dev_null         | OK     | 3.31               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-stdio            | OK     | 0.64               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-sleep_timeout    | OK     | 3.26               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker           | OK     | 11.26              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-rtc              | OK     | 4.51               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-cstring          | FAIL   | 1.55               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-cpp              | OK     | 1.46               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-timeout          | OK     | 11.45              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-basic            | OK     | 1.24               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker_3         | OK     | 11.3               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker_2         | OK     | 11.28              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-heap_and_stack   | OK     | 1.46               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-hello            | OK     | 0.29               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-time_us          | OK     | 11.26              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-stl              | OK     | 1.72               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-echo             | OK     | 4.21               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-detect           | OK     | 0.36               | shell       |
+---------------+---------------+------------------------------------+--------+--------------------+-------------+

Result: 1 FAIL / 19 OK
completed in 239.81 sec