### PR TITLE
Fix CriticalSectionLock class on Nordic platform.

### DIFF
--- a/core-util/CriticalSectionLock.h
+++ b/core-util/CriticalSectionLock.h
@@ -23,6 +23,7 @@
 #include "cmsis-core/core_generic.h"
 #ifdef TARGET_NORDIC
 #include "nrf_soc.h"
+#include "nrf_sdm.h"
 #endif /* #ifdef TARGET_NORDIC */
 #else  /* #ifdef TARGET_LIKE_POSIX */
 #include <assert.h>
@@ -51,7 +52,24 @@ class CriticalSectionLock {
 public:
     CriticalSectionLock() {
 #ifdef TARGET_NORDIC
-        sd_nvic_critical_region_enter(&_state);
+        // get the state of exceptions for the CPU
+        _PRIMASK_state = __get_PRIMASK();
+
+        // if exceptions are not enabled, there is nothing more to do
+        if(_PRIMASK_state == 1) {
+          _use_softdevice_routine = false;
+        } else {
+          // otherwise, use soft device routine if softdevice is running or disable
+          // the irq if softdevice is not running
+          uint8_t sd_enabled;
+          if((sd_softdevice_is_enabled(&sd_enabled) == NRF_SUCCESS) && sd_enabled == 1) {
+            _use_softdevice_routine = true;
+            sd_nvic_critical_region_enter(&_sd_state);
+          } else {
+            _use_softdevice_routine = false;
+            __disable_irq();
+          }
+        }
 #elif defined(TARGET_LIKE_POSIX)
         if (++IRQNestingDepth > 1) {
             return;
@@ -71,7 +89,11 @@ public:
 
     ~CriticalSectionLock() {
 #ifdef TARGET_NORDIC
-        sd_nvic_critical_region_exit(_state);
+        if(_use_softdevice_routine) {
+          sd_nvic_critical_region_exit(_sd_state);
+        } else {
+          __set_PRIMASK(_PRIMASK_state);
+        }
 #elif defined(TARGET_LIKE_POSIX)
         assert(IRQNestingDepth > 0);
         if (--IRQNestingDepth == 0) {
@@ -85,7 +107,11 @@ public:
 
 private:
 #ifdef TARGET_NORDIC
-    uint8_t  _state;
+    union {
+      uint32_t _PRIMASK_state;
+      uint8_t  _sd_state;
+    };
+    bool _use_softdevice_routine;
 #elif defined(TARGET_LIKE_POSIX)
     unsigned IRQNestingDepth;
     sigset_t oldSigSet;


### PR DESCRIPTION
Previously, the CriticalSectionLock on Nordic platform was only working if
the soft device was running and the interrupts enabled.

Otherwise if the soft device was not running:
  * If the interrupts were enabled, the CriticalSectionLock didn't work as intented (not disabling interrupts).
  * If the interrupts were disabled, the construction of CriticalSectionLock instances ended into an Hard fault.

This change require the merge of https://github.com/ARMmbed/mbed-hal-nrf51822-mcu/pull/34 otherwise, once minar will try to go to sleep with the soft device not running, it will end by an Hard fault.

@rgrover 