### PR TITLE
Added newline termination for runtime errors

### DIFF
--- a/source/assert_mbed.c
+++ b/source/assert_mbed.c
@@ -37,7 +37,7 @@ void core_util_runtime_error_internal(const char *file, int line, const char* fo
     va_start(arg, format);
     vfprintf(stderr, format, arg);
     va_end(arg);
-    fprintf(stderr, "\r\n");
+    fprintf(stderr, "\n");
 #endif
     exit(1);
 }
@@ -48,7 +48,7 @@ void core_util_assert_internal(const char *expr, const char *file, int line, con
     fprintf(stderr, "assertation failed: %s, file: %s, line %d", expr, file, line);
     if (msg)
         fprintf(stderr, " (%s)", msg);
-    fprintf(stderr, "\r\n");
+    fprintf(stderr, "\n");
 #endif
     mbed_die();
 }

--- a/source/assert_mbed.c
+++ b/source/assert_mbed.c
@@ -37,6 +37,7 @@ void core_util_runtime_error_internal(const char *file, int line, const char* fo
     va_start(arg, format);
     vfprintf(stderr, format, arg);
     va_end(arg);
+    fprintf(stderr, "\r\n");
 #endif
     exit(1);
 }


### PR DESCRIPTION
This makes it possible to detect runtime errors using mbedgt
(which is generally reading the serial port line by line, so it
expects to have newline terminators).