### PR TITLE
Forbid copying of core-util container classes

### DIFF
--- a/core-util/Array.h
+++ b/core-util/Array.h
@@ -248,6 +248,9 @@ private:
     size_t _element_size, _grow_capacity;
     volatile unsigned _capacity, _elements;
     unsigned _alignment;
+
+    Array(const Array&);
+    Array& operator =(const Array&);
 };
 
 } // namespace util

--- a/core-util/Array.h
+++ b/core-util/Array.h
@@ -249,8 +249,10 @@ private:
     volatile unsigned _capacity, _elements;
     unsigned _alignment;
 
-    Array(const Array&);
-    Array& operator =(const Array&);
+    Array(const Array&) = delete;
+    Array(Array&&) = delete;
+    Array& operator =(const Array&) = delete;
+    Array& operator =(Array&&) = delete;
 };
 
 } // namespace util

--- a/core-util/Array.h
+++ b/core-util/Array.h
@@ -47,6 +47,12 @@ public:
     Array(): _head(NULL) {
     }
 
+    /* Forbid copy and assignment */
+    Array(const Array&) = delete;
+    Array(Array&&) = delete;
+    Array& operator =(const Array&) = delete;
+    Array& operator =(Array&&) = delete;
+
     ~Array() {
         // We have copies of elements of type T in our array, so destroy them first
         for (unsigned i = 0; i < _elements; i ++) {
@@ -248,11 +254,6 @@ private:
     size_t _element_size, _grow_capacity;
     volatile unsigned _capacity, _elements;
     unsigned _alignment;
-
-    Array(const Array&) = delete;
-    Array(Array&&) = delete;
-    Array& operator =(const Array&) = delete;
-    Array& operator =(Array&&) = delete;
 };
 
 } // namespace util

--- a/core-util/BinaryHeap.h
+++ b/core-util/BinaryHeap.h
@@ -96,6 +96,12 @@ public:
     BinaryHeap(const Comparator& comparator = Comparator()): _array(), _comparator(comparator) {
     }
 
+    /* Forbid copy and assignment */
+    BinaryHeap(const BinaryHeap&) = delete;
+    BinaryHeap(BinaryHeap&&) = delete;
+    BinaryHeap& operator =(const BinaryHeap&) = delete;
+    BinaryHeap& operator =(BinaryHeap&&) = delete;
+
     /** Initialize the heap
       * @param initial_capacity initial capacity of the heap
       * @param grow_capacity number of elements to add when the heap's capacity is exceeded
@@ -277,9 +283,6 @@ private:
     Array<T> _array;
     Comparator _comparator;
     volatile size_t _elements;
-
-    BinaryHeap(const BinaryHeap&);
-    BinaryHeap& operator =(const BinaryHeap&);
 };
 
 } // namespace util

--- a/core-util/BinaryHeap.h
+++ b/core-util/BinaryHeap.h
@@ -277,6 +277,9 @@ private:
     Array<T> _array;
     Comparator _comparator;
     volatile size_t _elements;
+
+    BinaryHeap(const BinaryHeap&);
+    BinaryHeap& operator =(const BinaryHeap&);
 };
 
 } // namespace util

--- a/core-util/ExtendablePoolAllocator.h
+++ b/core-util/ExtendablePoolAllocator.h
@@ -97,8 +97,10 @@ private:
     UAllocTraits_t _alloc_traits;
     unsigned _alignment;
 
-    ExtendablePoolAllocator(const ExtendablePoolAllocator&);
-    ExtendablePoolAllocator& operator =(const ExtendablePoolAllocator&);
+    ExtendablePoolAllocator(const ExtendablePoolAllocator&) = delete;
+    ExtendablePoolAllocator(ExtendablePoolAllocator&&) = delete;
+    ExtendablePoolAllocator& operator =(const ExtendablePoolAllocator&) = delete;
+    ExtendablePoolAllocator& operator =(ExtendablePoolAllocator&&) = delete;
 };
 
 } // namespace util

--- a/core-util/ExtendablePoolAllocator.h
+++ b/core-util/ExtendablePoolAllocator.h
@@ -96,6 +96,9 @@ private:
     size_t _element_size, _new_pool_elements;
     UAllocTraits_t _alloc_traits;
     unsigned _alignment;
+
+    ExtendablePoolAllocator(const ExtendablePoolAllocator&);
+    ExtendablePoolAllocator& operator =(const ExtendablePoolAllocator&);
 };
 
 } // namespace util

--- a/core-util/ExtendablePoolAllocator.h
+++ b/core-util/ExtendablePoolAllocator.h
@@ -41,6 +41,12 @@ public:
       */
     ExtendablePoolAllocator();
 
+    /* Forbid copy and assignment */
+    ExtendablePoolAllocator(const ExtendablePoolAllocator&) = delete;
+    ExtendablePoolAllocator(ExtendablePoolAllocator&&) = delete;
+    ExtendablePoolAllocator& operator =(const ExtendablePoolAllocator&) = delete;
+    ExtendablePoolAllocator& operator =(ExtendablePoolAllocator&&) = delete;
+
     /** Destructor. It will automatically free all allocated memory
       */
     ~ExtendablePoolAllocator();
@@ -96,11 +102,6 @@ private:
     size_t _element_size, _new_pool_elements;
     UAllocTraits_t _alloc_traits;
     unsigned _alignment;
-
-    ExtendablePoolAllocator(const ExtendablePoolAllocator&) = delete;
-    ExtendablePoolAllocator(ExtendablePoolAllocator&&) = delete;
-    ExtendablePoolAllocator& operator =(const ExtendablePoolAllocator&) = delete;
-    ExtendablePoolAllocator& operator =(ExtendablePoolAllocator&&) = delete;
 };
 
 } // namespace util

--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -95,8 +95,10 @@ private:
     void *_start, *_free_block, *_end;
     size_t _element_size;
 
-    PoolAllocator(const PoolAllocator&);
-    PoolAllocator& operator =(const PoolAllocator&);
+    PoolAllocator(const PoolAllocator&) = delete;
+    PoolAllocator(PoolAllocator&&) = delete;
+    PoolAllocator& operator =(const PoolAllocator&) = delete;
+    PoolAllocator& operator =(PoolAllocator&&) = delete;
 };
 
 } // namespace util

--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -94,6 +94,9 @@ private:
 
     void *_start, *_free_block, *_end;
     size_t _element_size;
+
+    PoolAllocator(const PoolAllocator&);
+    PoolAllocator& operator =(const PoolAllocator&);
 };
 
 } // namespace util

--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -47,6 +47,12 @@ public:
       */
     PoolAllocator(void *start, size_t elements, size_t element_size, unsigned alignment = MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN);
 
+    /* Forbid copy and assignment */
+    PoolAllocator(const PoolAllocator&) = delete;
+    PoolAllocator(PoolAllocator&&) = delete;
+    PoolAllocator& operator =(const PoolAllocator&) = delete;
+    PoolAllocator& operator =(PoolAllocator&&) = delete;
+
     /** Allocate a new element from the pool
      * @returns the address of the new element or NULL for error
      */
@@ -94,11 +100,6 @@ private:
 
     void *_start, *_free_block, *_end;
     size_t _element_size;
-
-    PoolAllocator(const PoolAllocator&) = delete;
-    PoolAllocator(PoolAllocator&&) = delete;
-    PoolAllocator& operator =(const PoolAllocator&) = delete;
-    PoolAllocator& operator =(PoolAllocator&&) = delete;
 };
 
 } // namespace util


### PR DESCRIPTION
The core-util allocators (PoolAllocator, ExtendablePoolAllocator,
Array and BinaryHeap) don't have well defined copy semantics, thus
it's better to explicitly forbid copying than to rely on the
copy constructors and assignment operators generated automatically
by the compiler.

Fixes #11.