### PR TITLE
Module - update mbed drivers dep

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   "targetDependencies": {
     "mbed": {
       "cmsis-core": "^1.0.0",
-      "mbed-drivers": "~0.11.1"
+      "mbed-drivers": "~0.12.0"
     }
   },
   "scripts": {


### PR DESCRIPTION
If this module gets new major version, we will need to update ualloc, minar. I am not owner to those 2.