### PR TITLE
Add support for uninitialized data sections

### DIFF
--- a/core-util/uninitialized.h
+++ b/core-util/uninitialized.h
@@ -1,0 +1,68 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2015-2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __CORE_UTIL_UNINITIALIZED_H__
+#define __CORE_UTIL_UNINITIALIZED_H__
+
+/**
+ * The following macros are used to place uninitialized data in a dedicated
+ * section, which is not touched by the C/C++ library at startup time. They can
+ * be used, for example, to hold data and state across reboots.
+ *
+ * Note: These macros require additional support from the platform linker
+ * script.
+ *
+ * In GCC:
+ *      .uninitialized (NOLOAD):
+ *      {
+ *          . = ALIGN(32);
+ *          __uninitialized_start = .;
+ *          *(.uninitialized)
+ *          KEEP(*(.keep.uninitialized))
+ *          . = ALIGN(32);
+ *          __uninitialized_end = .;
+ *      } > RAM
+ *
+ *  In ARMCC:
+ *      ER_UNINITIALIZED +0 UNINIT NOCOMPRESS
+        {
+            * (.keep.uninitialized)
+            * (.uninitialized)
+        }
+ *  which also requires an additional linker option:
+ *      set(CMAKE_EXE_LINKER_FLAGS_INIT
+ *          "${CMAKE_EXE_LINKER_FLAGS_INIT} --keep=\"*(.keep*)\"")
+ *  to make sure that unused symbols are not discarded. The GNU extensions must
+ *  be enabled (--gnu).
+ */
+
+#if defined(__GNUC__) || defined (__CC_ARM) || defined(__clang__)
+
+#ifndef __uninitialized
+    #define __uninitialized __attribute__((section(".uninitialized")))
+#endif
+
+#ifndef __force_uninitialized
+    #define __force_uninitialized __attribute__((section(".keep.uninitialized")))
+#endif
+
+#else
+
+#error "This compiler is not yet supported by core-util/uninitialized.h."
+
+#endif /* defined(__GNUC__) || defined (__CC_ARM) || defined(__clang__) */
+
+#endif /* __CORE_UTIL_UNINITIALIZED_H__ */

--- a/test/uninitialized/main.cpp
+++ b/test/uninitialized/main.cpp
@@ -1,0 +1,57 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdint.h>
+#include "cmsis-core/core_generic.h"
+#include "mbed-drivers/test_env.h"
+#include "core-util/uninitialized.h"
+
+#define TEST_C_INIT      0xDEADBEEFUL
+#define TEST_MANUAL_INIT 0xACCE55EDUL
+
+__uninitialized uint32_t g_state = TEST_C_INIT;
+
+void app_start(int, char*[])
+{
+    if (g_state == TEST_C_INIT) {
+        /* First run: Check that the g_state does *not* hold the initialized
+         * data. */
+        MBED_HOSTTEST_TIMEOUT(5);
+        MBED_HOSTTEST_SELECT(default);
+        MBED_HOSTTEST_DESCRIPTION(uninitialized section);
+        MBED_HOSTTEST_START("UNINITIALIZED_SECTION_TEST");
+        MBED_HOSTTEST_RESULT(false);
+    } else if (g_state != TEST_MANUAL_INIT) {
+        MBED_HOSTTEST_TIMEOUT(5);
+        MBED_HOSTTEST_SELECT(default);
+        MBED_HOSTTEST_DESCRIPTION(uninitialized section);
+        MBED_HOSTTEST_START("UNINITIALIZED_SECTION_TEST");
+
+        /* First or subsequent runs: If this is the first run, initialize the
+         * state and reset. If this code is run again after the first run it
+         * means the state is not kept across reboots. Eventually, the test will
+         * timeout, failing. */
+        g_state = TEST_MANUAL_INIT;
+        NVIC_SystemReset();
+    } else {
+        /* Second run: The data was correctly initialized and kept across a
+         * system reset. */
+        g_state = 0;
+        MBED_HOSTTEST_RESULT(true);
+    }
+
+    return;
+}


### PR DESCRIPTION
An uninitialized linker script section is never touched by the C/C++ library,
allowing state to be kept across system reboots.

The macros introduced here require additional linker script support. See
comments in core-util/uninitialized.h and see
https://github.com/ARMmbed/target-frdm-k64f-gcc/pull/18 for reference.

@bogdanm @autopulated @0xc0170 

Replaces https://github.com/ARMmbed/compiler-polyfill/pull/5