### PR TITLE
Test function pointer - remove serial baud change

### DIFF
--- a/test/FunctionPointer/main.cpp
+++ b/test/FunctionPointer/main.cpp
@@ -41,9 +41,6 @@ void bareprint() {
 }
 
 void runTest(void) {
-    static Serial pc(USBTX, USBRX);
-    pc.baud(115200);
-
     MBED_HOSTTEST_TIMEOUT(10);
     MBED_HOSTTEST_SELECT(default_auto);
     MBED_HOSTTEST_DESCRIPTION(FunctionPointer test);


### PR DESCRIPTION
Fixes #49 issue.

```
+---------------+---------------+----------------------------------------+---------+--------------------+-------------+
| target        | platform_name | test                                   | result  | elapsed_time (sec) | copy_method |
+---------------+---------------+----------------------------------------+---------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | core-util-test-array                   | OK      | 2.38               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | OK      | 2.43               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | OK      | 7.73               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-extendablepoolallocator | OK      | 2.43               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-functionpointer         | OK      | 2.95               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-poolallocator           | OK      | 2.42               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-sbrk-mini               | OK      | 2.38               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-sharedpointer           | OK      | 2.41               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-uninitialized           | TIMEOUT | 10.92              | shell       |
+---------------+---------------+----------------------------------------+---------+--------------------+-------------+
```

@AlessandroA core-util-test-uninitialized timeouts for me, I fetched latest modules, did I miss anything?

@bogdanm @PrzemekWirkus 