### PR TITLE
[devel_transport] Port tests to async model

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,11 +24,12 @@
   "targetDependencies": {
     "mbed": {
       "cmsis-core": "^1.0.0",
-      "mbed-drivers": "~0.12.0",
-      "greentea-client": "^0.1.4",
-      "utest": "^1.7.0",
-      "unity": "^2.0.1"
+      "mbed-drivers": "~0.12.0"
     }
+  },
+  "testDependencies": {
+    "unity": "^2.0.0",
+    "greentea-client": "~0.1.4"
   },
   "scripts": {
     "testReporter": [

--- a/module.json
+++ b/module.json
@@ -24,7 +24,10 @@
   "targetDependencies": {
     "mbed": {
       "cmsis-core": "^1.0.0",
-      "mbed-drivers": "~0.12.0"
+      "mbed-drivers": "~0.12.0",
+      "greentea-client": "^0.1.4",
+      "utest": "^1.7.0",
+      "unity": "^2.0.1"
     }
   },
   "scripts": {

--- a/test/Array/main.cpp
+++ b/test/Array/main.cpp
@@ -37,37 +37,37 @@ static void test_pod() {
     for (unsigned i = 0; i < initial_capacity; i ++ ) {
         array.push_back(i);
     }
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity);
+    TEST_ASSERT_EQUAL(initial_capacity, array.get_num_elements());
     for (unsigned i = 0; i < initial_capacity; i ++) {
-        TEST_ASSERT_TRUE(array[i] == i);
+        TEST_ASSERT_EQUAL(i, array[i]);
     }
-    TEST_ASSERT_TRUE(array.get_num_zones() == 1);
+    TEST_ASSERT_EQUAL(1, array.get_num_zones());
 
     // Add another element, this should trigger the creation of another zone
     array.push_back(1000);
-    TEST_ASSERT_TRUE(array.get_num_zones() == 2);
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + 1);
+    TEST_ASSERT_EQUAL(2, array.get_num_zones());
+    TEST_ASSERT_EQUAL(initial_capacity + 1, array.get_num_elements());
     // Fill the second zone too
     for (unsigned i = 1; i < grow_capacity; i ++) {
         array.push_back(1000 + i);
     }
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity);
+    TEST_ASSERT_EQUAL(initial_capacity + grow_capacity, array.get_num_elements());
     for (unsigned i = 0; i < grow_capacity; i ++) {
-        TEST_ASSERT_TRUE(array.at(i + initial_capacity) == 1000 + i);
+        TEST_ASSERT_EQUAL(1000 + i, array.at(i + initial_capacity));
     }
-    TEST_ASSERT_TRUE(array.get_num_zones() == 2);
+    TEST_ASSERT_EQUAL(2, array.get_num_zones());
     unsigned save_for_later = array[initial_capacity + grow_capacity - 1];
     // Add yet another element, which should result in the creation of another zone
     array.push_back(10000);
-    TEST_ASSERT_TRUE(array[initial_capacity + grow_capacity] == 10000);
-    TEST_ASSERT_TRUE(array.get_num_zones() == 3);
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity + 1);
+    TEST_ASSERT_EQUAL(10000, array[initial_capacity + grow_capacity]);
+    TEST_ASSERT_EQUAL(3, array.get_num_zones());
+    TEST_ASSERT_EQUAL(initial_capacity + grow_capacity + 1, array.get_num_elements());
 
     // Remove the last element
     array.pop_back();
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity);
-    TEST_ASSERT_TRUE(array[array.get_num_elements() - 1] == save_for_later);
-    TEST_ASSERT_TRUE(array.get_num_zones() == 3); // the array doesn't (yet?) shrink
+    TEST_ASSERT_EQUAL(initial_capacity + grow_capacity, array.get_num_elements());
+    TEST_ASSERT_EQUAL(save_for_later, array[array.get_num_elements() - 1]);
+    TEST_ASSERT_EQUAL(3, array.get_num_zones()); // the array doesn't (yet?) shrink
 
     // Simple bubble sort test illustrating moving around elements in the array
     const size_t total = initial_capacity + grow_capacity;
@@ -85,10 +85,10 @@ static void test_pod() {
         }
     }
     for (unsigned i = 0; i < total; i ++) {
-        TEST_ASSERT_TRUE(array[i] == i);
+        TEST_ASSERT_EQUAL(i, array[i]);
     }
 
-    TEST_ASSERT_TRUE(array.get_num_zones() == 3);
+    TEST_ASSERT_EQUAL(3, array.get_num_zones());
 }
 
 struct Test {
@@ -144,10 +144,10 @@ static void test_non_pod() {
     // Pop the last element from array (checks if destructor is called)
     array.pop_back();
 
-    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity - 1);
-    TEST_ASSERT_TRUE(array.get_num_zones() == 1);
+    TEST_ASSERT_EQUAL(initial_capacity - 1, array.get_num_elements());
+    TEST_ASSERT_EQUAL(1, array.get_num_zones());
     }
-    TEST_ASSERT_TRUE(Test::inst_count == 0);
+    TEST_ASSERT_EQUAL(0, Test::inst_count);
 }
 
 static status_t test_setup(const size_t number_of_cases) {

--- a/test/Array/main.cpp
+++ b/test/Array/main.cpp
@@ -16,10 +16,14 @@
  */
 
 #include "core-util/Array.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
+#include "mbed-drivers/mbed.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
 #include <stdio.h>
 #include <stdlib.h>
 
+using namespace utest::v1;
 using namespace mbed::util;
 
 static void test_pod() {
@@ -27,43 +31,43 @@ static void test_pod() {
 
     const size_t initial_capacity = 20, grow_capacity = 12, alignment = 4;
     UAllocTraits_t traits = {0};
-    MBED_HOSTTEST_ASSERT(array.init(initial_capacity, grow_capacity, traits, alignment));
+    TEST_ASSERT_TRUE(array.init(initial_capacity, grow_capacity, traits, alignment));
 
     // Start filling the array
     for (unsigned i = 0; i < initial_capacity; i ++ ) {
         array.push_back(i);
     }
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity);
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity);
     for (unsigned i = 0; i < initial_capacity; i ++) {
-        MBED_HOSTTEST_ASSERT(array[i] == i);
+        TEST_ASSERT_TRUE(array[i] == i);
     }
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 1);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 1);
 
     // Add another element, this should trigger the creation of another zone
     array.push_back(1000);
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 2);
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity + 1);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 2);
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + 1);
     // Fill the second zone too
     for (unsigned i = 1; i < grow_capacity; i ++) {
         array.push_back(1000 + i);
     }
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity + grow_capacity);
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity);
     for (unsigned i = 0; i < grow_capacity; i ++) {
-        MBED_HOSTTEST_ASSERT(array.at(i + initial_capacity) == 1000 + i);
+        TEST_ASSERT_TRUE(array.at(i + initial_capacity) == 1000 + i);
     }
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 2);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 2);
     unsigned save_for_later = array[initial_capacity + grow_capacity - 1];
     // Add yet another element, which should result in the creation of another zone
     array.push_back(10000);
-    MBED_HOSTTEST_ASSERT(array[initial_capacity + grow_capacity] == 10000);
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 3);
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity + grow_capacity + 1);
+    TEST_ASSERT_TRUE(array[initial_capacity + grow_capacity] == 10000);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 3);
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity + 1);
 
     // Remove the last element
     array.pop_back();
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity + grow_capacity);
-    MBED_HOSTTEST_ASSERT(array[array.get_num_elements() - 1] == save_for_later);
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 3); // the array doesn't (yet?) shrink
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity + grow_capacity);
+    TEST_ASSERT_TRUE(array[array.get_num_elements() - 1] == save_for_later);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 3); // the array doesn't (yet?) shrink
 
     // Simple bubble sort test illustrating moving around elements in the array
     const size_t total = initial_capacity + grow_capacity;
@@ -81,10 +85,10 @@ static void test_pod() {
         }
     }
     for (unsigned i = 0; i < total; i ++) {
-        MBED_HOSTTEST_ASSERT(array[i] == i);
+        TEST_ASSERT_TRUE(array[i] == i);
     }
 
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 3);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 3);
 }
 
 struct Test {
@@ -112,11 +116,12 @@ struct Test {
 int Test::inst_count = 0;
 
 static void test_non_pod() {
+    {
     Array<Test> array;
 
     const size_t initial_capacity = 10, grow_capacity = 6, alignment = 4;
     UAllocTraits_t traits = {0};
-    MBED_HOSTTEST_ASSERT(array.init(initial_capacity, grow_capacity, traits, alignment));
+    TEST_ASSERT_TRUE(array.init(initial_capacity, grow_capacity, traits, alignment));
 
     // Just fill the first part of the array and verify
     unsigned idx;
@@ -124,7 +129,7 @@ static void test_non_pod() {
         array.push_back(Test(idx, 'a'));
     }
     for (idx = 0; idx < initial_capacity; idx ++) {
-        MBED_HOSTTEST_ASSERT(array[idx] == Test(idx, 'a'));
+        TEST_ASSERT_TRUE(array[idx] == Test(idx, 'a'));
     }
 
     // Now override what we wrote with different data
@@ -133,26 +138,37 @@ static void test_non_pod() {
     }
     for (idx = 0; idx < initial_capacity; idx ++) {
         const Test& t = array[idx];
-        MBED_HOSTTEST_ASSERT(t == Test(idx, 'b'));
+        TEST_ASSERT_TRUE(t == Test(idx, 'b'));
     }
 
     // Pop the last element from array (checks if destructor is called)
     array.pop_back();
 
-    MBED_HOSTTEST_ASSERT(array.get_num_elements() == initial_capacity - 1);
-    MBED_HOSTTEST_ASSERT(array.get_num_zones() == 1);
+    TEST_ASSERT_TRUE(array.get_num_elements() == initial_capacity - 1);
+    TEST_ASSERT_TRUE(array.get_num_zones() == 1);
+    }
+    TEST_ASSERT_TRUE(Test::inst_count == 0);
 }
 
+static status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(5, "default_auto");
+
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+static Case cases[] = {
+    Case("Array  - test with plain old data", test_pod, greentea_failure_handler),
+    Case("Array  - test with complex data", test_non_pod, greentea_failure_handler)
+};
+
+static Specification specification(test_setup, cases, greentea_test_teardown_handler);
+
 void app_start(int, char**) {
-    MBED_HOSTTEST_TIMEOUT(5);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(mbed-util array  test);
-    MBED_HOSTTEST_START("MBED_UTIL_ARRAY_TEST");
-
-    test_pod(); // test with "plain old data"
-    test_non_pod(); // test with complex data
-    MBED_HOSTTEST_ASSERT(Test::inst_count == 0);
-
-    MBED_HOSTTEST_RESULT(true);
+    Harness::run(specification);
 }
 

--- a/test/BinaryHeap/main.cpp
+++ b/test/BinaryHeap/main.cpp
@@ -16,10 +16,14 @@
  */
 
 #include "core-util/BinaryHeap.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
+#include "mbed-drivers/mbed.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
 #include <stdio.h>
 #include <stdlib.h>
 
+using namespace utest::v1;
 using namespace mbed::util;
 
 template<typename T, typename Compare>
@@ -29,46 +33,46 @@ static void test_heap(const T* data, unsigned data_size, const T* sorted_data,
     BinaryHeap<T, Compare> heap;
     const size_t initial_capacity = data_size / 2, grow_capacity = (data_size * 3) / 2, alignment = 4;
     UAllocTraits_t traits = {0};
-    MBED_HOSTTEST_ASSERT(heap.init(initial_capacity, grow_capacity, traits, alignment));
+    TEST_ASSERT_TRUE(heap.init(initial_capacity, grow_capacity, traits, alignment));
 
    // Fill the heap with data
     for (unsigned i = 0; i < data_size; i++) {
         heap.insert(data[i]);
-        MBED_HOSTTEST_ASSERT(heap.is_consistent());
+        TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    MBED_HOSTTEST_ASSERT(heap.get_num_elements() == data_size);
+    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size);
 
     // Remove and check root at each step
     for (unsigned i = 0; i < data_size; i ++) {
         T root = heap.get_root();
-        MBED_HOSTTEST_ASSERT(root == sorted_data[i]);
+        TEST_ASSERT_TRUE(root == sorted_data[i]);
         heap.remove_root();
-        MBED_HOSTTEST_ASSERT(heap.is_consistent());
+        TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    MBED_HOSTTEST_ASSERT(heap.is_empty());
+    TEST_ASSERT_TRUE(heap.is_empty());
 
     // Put everything back again
     for (unsigned i = 0; i < data_size; i++) {
         heap.insert(data[i]);
-        MBED_HOSTTEST_ASSERT(heap.is_consistent());
+        TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    MBED_HOSTTEST_ASSERT(heap.get_num_elements() == data_size);
+    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size);
 
     // And check removing
     for (unsigned i = 0; i < removed_size; i ++) {
-        MBED_HOSTTEST_ASSERT(heap.remove(to_remove[i]));
-        MBED_HOSTTEST_ASSERT(heap.is_consistent());
+        TEST_ASSERT_TRUE(heap.remove(to_remove[i]));
+        TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    MBED_HOSTTEST_ASSERT(!heap.remove(not_in_heap)); // this element is not in the heap
-    MBED_HOSTTEST_ASSERT(heap.get_num_elements() == data_size - removed_size);
+    TEST_ASSERT_TRUE(!heap.remove(not_in_heap)); // this element is not in the heap
+    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size - removed_size);
     // Remove and check root at each step
     for (unsigned i = 0; i < data_size - removed_size; i ++) {
         T root = heap.pop_root();
-        MBED_HOSTTEST_ASSERT(root == sorted_after_remove[i]);
-        MBED_HOSTTEST_ASSERT(heap.is_consistent());
+        TEST_ASSERT_TRUE(root == sorted_after_remove[i]);
+        TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    MBED_HOSTTEST_ASSERT(heap.is_empty());
-    MBED_HOSTTEST_ASSERT(heap.get_num_elements() == 0);
+    TEST_ASSERT_TRUE(heap.is_empty());
+    TEST_ASSERT_TRUE(heap.get_num_elements() == 0);
 }
 
 static void test_min_heap_pod() {
@@ -129,6 +133,7 @@ struct Test {
 int Test::inst_count = 0;
 
 static void test_min_heap_non_pod() {
+    {
     Test data[] = {20, 13, 8, 7, 100, -50, 0, 16, 1000, 2};
     Test sorted_data[] = {-50, 0, 2, 7, 8, 13, 16, 20, 100, 1000};
     Test to_remove[] = {-50, 100, 8, 2};
@@ -138,10 +143,13 @@ static void test_min_heap_non_pod() {
     test_heap<Test, MinCompare<Test> >(data, sizeof(data)/sizeof(Test), sorted_data,
                    to_remove, sizeof(to_remove)/sizeof(Test), sorted_after_remove,
                    2000);
+    }
+    TEST_ASSERT_TRUE(Test::inst_count == 0);
     printf("********** Ending test_min_heap_non_pod()\r\n");
 }
 
 static void test_max_heap_non_pod() {
+    {
     Test data[] = {291, 62, 364, 63, 753, 325, -382, -736, -930, -927, 734, -591, 136, 753, 576, -59, -930, -700, -380, 764};
     Test sorted_data[] = {764, 753, 753, 734, 576, 364, 325, 291, 136, 63, 62, -59, -380, -382, -591, -700, -736, -927, -930, -930};
     Test to_remove[] = {-927, 576, 63, 753, -930, 364, 753}; // this will remove two elements with the same value
@@ -151,21 +159,32 @@ static void test_max_heap_non_pod() {
     test_heap<Test, MaxCompare<Test> >(data, sizeof(data)/sizeof(Test), sorted_data,
                    to_remove, sizeof(to_remove)/sizeof(Test), sorted_after_remove,
                    2000);
+    }
+    TEST_ASSERT_TRUE(Test::inst_count == 0);
     printf("********** Ending test_max_heap_non_pod()\r\n");
 }
 
-void app_start(int, char **) {
-    MBED_HOSTTEST_TIMEOUT(5);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(mbed-util binary heap test);
-    MBED_HOSTTEST_START("MBED_UTIL_BINARY_HEAP_TEST");
+static status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(5, "default_auto");
 
-    test_min_heap_pod();
-    test_max_heap_pod();
-    test_min_heap_non_pod();
-    MBED_HOSTTEST_ASSERT(Test::inst_count == 0);
-    test_max_heap_non_pod();
-    MBED_HOSTTEST_ASSERT(Test::inst_count == 0);
-    MBED_HOSTTEST_RESULT(true);
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+static Case cases[] = {
+    Case("BinaryHeap  - test_min_heap_pod", test_min_heap_pod, greentea_failure_handler),
+    Case("BinaryHeap  - test_max_heap_pod", test_max_heap_pod, greentea_failure_handler),
+    Case("BinaryHeap  - test_min_heap_non_pod", test_min_heap_non_pod, greentea_failure_handler),
+    Case("BinaryHeap  - test_max_heap_non_pod", test_max_heap_non_pod, greentea_failure_handler)
+};
+
+static Specification specification(test_setup, cases, greentea_test_teardown_handler);
+
+void app_start(int, char**) {
+    Harness::run(specification);
 }
 

--- a/test/BinaryHeap/main.cpp
+++ b/test/BinaryHeap/main.cpp
@@ -40,7 +40,7 @@ static void test_heap(const T* data, unsigned data_size, const T* sorted_data,
         heap.insert(data[i]);
         TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size);
+    TEST_ASSERT_EQUAL(data_size, heap.get_num_elements());
 
     // Remove and check root at each step
     for (unsigned i = 0; i < data_size; i ++) {
@@ -56,7 +56,7 @@ static void test_heap(const T* data, unsigned data_size, const T* sorted_data,
         heap.insert(data[i]);
         TEST_ASSERT_TRUE(heap.is_consistent());
     }
-    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size);
+    TEST_ASSERT_EQUAL(data_size, heap.get_num_elements());
 
     // And check removing
     for (unsigned i = 0; i < removed_size; i ++) {
@@ -64,7 +64,7 @@ static void test_heap(const T* data, unsigned data_size, const T* sorted_data,
         TEST_ASSERT_TRUE(heap.is_consistent());
     }
     TEST_ASSERT_TRUE(!heap.remove(not_in_heap)); // this element is not in the heap
-    TEST_ASSERT_TRUE(heap.get_num_elements() == data_size - removed_size);
+    TEST_ASSERT_EQUAL(data_size - removed_size, heap.get_num_elements());
     // Remove and check root at each step
     for (unsigned i = 0; i < data_size - removed_size; i ++) {
         T root = heap.pop_root();
@@ -72,7 +72,7 @@ static void test_heap(const T* data, unsigned data_size, const T* sorted_data,
         TEST_ASSERT_TRUE(heap.is_consistent());
     }
     TEST_ASSERT_TRUE(heap.is_empty());
-    TEST_ASSERT_TRUE(heap.get_num_elements() == 0);
+    TEST_ASSERT_EQUAL(0, heap.get_num_elements());
 }
 
 static void test_min_heap_pod() {
@@ -144,7 +144,7 @@ static void test_min_heap_non_pod() {
                    to_remove, sizeof(to_remove)/sizeof(Test), sorted_after_remove,
                    2000);
     }
-    TEST_ASSERT_TRUE(Test::inst_count == 0);
+    TEST_ASSERT_EQUAL(0, Test::inst_count);
     printf("********** Ending test_min_heap_non_pod()\r\n");
 }
 
@@ -160,7 +160,7 @@ static void test_max_heap_non_pod() {
                    to_remove, sizeof(to_remove)/sizeof(Test), sorted_after_remove,
                    2000);
     }
-    TEST_ASSERT_TRUE(Test::inst_count == 0);
+    TEST_ASSERT_EQUAL(0, Test::inst_count);
     printf("********** Ending test_max_heap_non_pod()\r\n");
 }
 

--- a/test/EventHandler/main.cpp
+++ b/test/EventHandler/main.cpp
@@ -259,7 +259,7 @@ static void test_funcs_nontca() {
     call_fp1("ptr to virtual method taking non-tc argument", fp2, MyArg("notest", 5, 8));
     call_fp1("ptr to virtual method taking non-tc argument (via base class pointer)", fp2, MyArg("notest", 5, 8));
     }
-    TEST_ASSERT_TRUE(MyArg::instcount == 0);
+    TEST_ASSERT_EQUAL(0, MyArg::instcount);
 }
 
 /******************************************************************************
@@ -288,7 +288,7 @@ static void test_array_of_events() {
         events[i].call();
     }
     }
-    TEST_ASSERT_TRUE(MyArg::instcount == 0);
+    TEST_ASSERT_EQUAL(0, MyArg::instcount);
 }
 
 /******************************************************************************
@@ -353,7 +353,7 @@ static void test_event_assignment_and_swap() {
     call_event("e2", e2);
     call_event("e3", e3);
     }
-    TEST_ASSERT_TRUE(MyArg::instcount == 0);
+    TEST_ASSERT_EQUAL(0, MyArg::instcount);
 }
 
 static status_t test_setup(const size_t number_of_cases) {

--- a/test/ExtendablePoolAllocator/main.cpp
+++ b/test/ExtendablePoolAllocator/main.cpp
@@ -43,25 +43,25 @@ static void test_extendable_pool_allocator() {
     for (unsigned i = 0; i < initial_elements; i ++) {
         TEST_ASSERT_TRUE(check_value_and_alignment(allocator.alloc()));
     }
-    TEST_ASSERT_TRUE(allocator.get_num_pools() == 1);
+    TEST_ASSERT_EQUAL(1, allocator.get_num_pools());
 
     // Allocating just another element should add another pool
     void *p = allocator.alloc();
     TEST_ASSERT_TRUE(check_value_and_alignment(p));
-    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
+    TEST_ASSERT_EQUAL(2, allocator.get_num_pools());
     // Fill the new pool
     for (unsigned i = 0; i < new_pool_elements - 1; i ++) {
         TEST_ASSERT_TRUE(check_value_and_alignment(allocator.alloc()));
     }
-    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
+    TEST_ASSERT_EQUAL(2, allocator.get_num_pools());
 
     // Free one previously allocated area
     allocator.free(p);
     // And allocate again. Since there's a single free place, it should be used now
     void *newp = allocator.alloc();
     TEST_ASSERT_TRUE(check_value_and_alignment(newp));
-    TEST_ASSERT_TRUE(newp == p);
-    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
+    TEST_ASSERT_EQUAL(p, newp);
+    TEST_ASSERT_EQUAL(2, allocator.get_num_pools());
 }
 
 static status_t test_setup(const size_t number_of_cases) {

--- a/test/ExtendablePoolAllocator/main.cpp
+++ b/test/ExtendablePoolAllocator/main.cpp
@@ -16,11 +16,14 @@
  */
 
 #include "core-util/ExtendablePoolAllocator.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
 #include "ualloc/ualloc.h"
 #include <stdio.h>
 #include <stdlib.h>
 
+using namespace utest::v1;
 using namespace mbed::util;
 
 static bool check_value_and_alignment(void *p, unsigned alignment = MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN) {
@@ -29,42 +32,50 @@ static bool check_value_and_alignment(void *p, unsigned alignment = MBED_UTIL_PO
     return ((uint32_t)p & (alignment - 1)) == 0;
 }
 
-void app_start(int, char**) {
-    MBED_HOSTTEST_TIMEOUT(5);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(mbed-util extendable pool allocator test);
-    MBED_HOSTTEST_START("MBED_UTIL_EXTENDABLE_POOL_ALLOCATOR_TEST");
-
+static void test_extendable_pool_allocator() {
     // Create the allocator
     const size_t initial_elements = 20, new_pool_elements = 12, element_size = 6;
     UAllocTraits_t traits = {0};
     ExtendablePoolAllocator allocator;
-    MBED_HOSTTEST_ASSERT(allocator.init(initial_elements, new_pool_elements, element_size, traits));
+    TEST_ASSERT_TRUE(allocator.init(initial_elements, new_pool_elements, element_size, traits));
 
     // Fill the first pool
     for (unsigned i = 0; i < initial_elements; i ++) {
-        MBED_HOSTTEST_ASSERT(check_value_and_alignment(allocator.alloc()));
+        TEST_ASSERT_TRUE(check_value_and_alignment(allocator.alloc()));
     }
-    MBED_HOSTTEST_ASSERT(allocator.get_num_pools() == 1);
+    TEST_ASSERT_TRUE(allocator.get_num_pools() == 1);
 
     // Allocating just another element should add another pool
     void *p = allocator.alloc();
-    MBED_HOSTTEST_ASSERT(check_value_and_alignment(p));
-    MBED_HOSTTEST_ASSERT(allocator.get_num_pools() == 2);
+    TEST_ASSERT_TRUE(check_value_and_alignment(p));
+    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
     // Fill the new pool
     for (unsigned i = 0; i < new_pool_elements - 1; i ++) {
-        MBED_HOSTTEST_ASSERT(check_value_and_alignment(allocator.alloc()));
+        TEST_ASSERT_TRUE(check_value_and_alignment(allocator.alloc()));
     }
-    MBED_HOSTTEST_ASSERT(allocator.get_num_pools() == 2);
+    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
 
     // Free one previously allocated area
     allocator.free(p);
     // And allocate again. Since there's a single free place, it should be used now
     void *newp = allocator.alloc();
-    MBED_HOSTTEST_ASSERT(check_value_and_alignment(newp));
-    MBED_HOSTTEST_ASSERT(newp == p);
-    MBED_HOSTTEST_ASSERT(allocator.get_num_pools() == 2);
-
-    MBED_HOSTTEST_RESULT(true);
+    TEST_ASSERT_TRUE(check_value_and_alignment(newp));
+    TEST_ASSERT_TRUE(newp == p);
+    TEST_ASSERT_TRUE(allocator.get_num_pools() == 2);
 }
 
+static status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(5, "default_auto");
+
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+static Case cases[] = {
+    Case("ExtendablePoolAllocator  - test_extendable_pool_allocator", test_extendable_pool_allocator)
+};
+
+static Specification specification(test_setup, cases, greentea_test_teardown_handler);
+
+void app_start(int, char**) {
+    Harness::run(specification);
+}

--- a/test/PoolAllocator/main.cpp
+++ b/test/PoolAllocator/main.cpp
@@ -30,7 +30,7 @@ void test_pool_allocator() {
     const size_t elements = 10, element_size = 6;
     const size_t aligned_size = (element_size + MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN - 1) & ~(MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN - 1);
     size_t pool_size = PoolAllocator::get_pool_size(elements, element_size);
-    TEST_ASSERT_TRUE(pool_size == elements * aligned_size);
+    TEST_ASSERT_EQUAL(elements * aligned_size, pool_size);
 
     void *start = malloc(pool_size);
     TEST_ASSERT_TRUE(start != NULL);
@@ -42,19 +42,19 @@ void test_pool_allocator() {
         p = allocator.alloc();
         TEST_ASSERT_TRUE(p != NULL);
         // Check alignment
-        TEST_ASSERT_TRUE(((uint32_t)p & (MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN - 1)) == 0);
+        TEST_ASSERT_EQUAL(0, ((uint32_t)p & (MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN - 1)));
         // Check spacing
         if (i > 0) {
-            TEST_ASSERT_TRUE(((uint32_t)p - (uint32_t)prev) == aligned_size);
+            TEST_ASSERT_EQUAL(aligned_size, ((uint32_t)p - (uint32_t)prev));
         } else {
             first = p;
-            TEST_ASSERT_TRUE(p == start);
+            TEST_ASSERT_EQUAL(start, p);
         }
         prev = p;
     }
 
     // No more space in the pool, we should get NULL now
-    TEST_ASSERT_TRUE(allocator.alloc() == NULL);
+    TEST_ASSERT_EQUAL(NULL, allocator.alloc());
 
     // Free the first element we allocated
     allocator.free(first);
@@ -62,9 +62,9 @@ void test_pool_allocator() {
     // Verify that we can allocate a single element now, and it has the same address
     // as the first element we allocated above
     p = allocator.alloc();
-    TEST_ASSERT_TRUE(p == first);
+    TEST_ASSERT_EQUAL(first, p);
     p = allocator.alloc();
-    TEST_ASSERT_TRUE(p == NULL);
+    TEST_ASSERT_EQUAL(NULL, p);
 }
 
 static status_t test_setup(const size_t number_of_cases) {

--- a/test/SharedPointer/main.cpp
+++ b/test/SharedPointer/main.cpp
@@ -17,9 +17,12 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
 #include "core-util/SharedPointer.h"
 
+using namespace utest::v1;
 using namespace mbed::util;
 
 static bool globalFlag = false;
@@ -43,47 +46,42 @@ private:
 };
 
 
-void app_start(int, char*[]) {
-    MBED_HOSTTEST_TIMEOUT(2);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(SharedPointer test);
-    MBED_HOSTTEST_START("SharedPointer_TEST");
-
+void test_shared_pointer() {
     /* Test 1: create SharedPointer from pointer */
     Number* ptr1 = new Number(1);
     SharedPointer<Number> sharedptr1(ptr1);
 
     // pointers match
-    MBED_HOSTTEST_ASSERT(sharedptr1.get() == ptr1);
+    TEST_ASSERT_TRUE(sharedptr1.get() == ptr1);
 
     // counter match
-    MBED_HOSTTEST_ASSERT(sharedptr1.use_count() == 1);
+    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
 
     // dereferencing works
-    MBED_HOSTTEST_ASSERT(sharedptr1->getNum() == 1);
+    TEST_ASSERT_TRUE(sharedptr1->getNum() == 1);
 
     /* Test 2: copy pointer */
     {
         SharedPointer<Number> sharedptr1copy;
 
         // NULL pointer is NULL
-        MBED_HOSTTEST_ASSERT(sharedptr1copy.get() == NULL);
-        MBED_HOSTTEST_ASSERT(sharedptr1copy.use_count() == 0);
+        TEST_ASSERT_TRUE(sharedptr1copy.get() == NULL);
+        TEST_ASSERT_TRUE(sharedptr1copy.use_count() == 0);
 
         // copy
         sharedptr1copy = sharedptr1;
 
         // raw pointer is consistent
-        MBED_HOSTTEST_ASSERT(sharedptr1copy.get() == ptr1);
-        MBED_HOSTTEST_ASSERT(sharedptr1copy.get() == sharedptr1.get());
+        TEST_ASSERT_TRUE(sharedptr1copy.get() == ptr1);
+        TEST_ASSERT_TRUE(sharedptr1copy.get() == sharedptr1.get());
 
         // reference count is accurate
-        MBED_HOSTTEST_ASSERT(sharedptr1.use_count() == 2);
-        MBED_HOSTTEST_ASSERT(sharedptr1copy.use_count() == 2);
+        TEST_ASSERT_TRUE(sharedptr1.use_count() == 2);
+        TEST_ASSERT_TRUE(sharedptr1copy.use_count() == 2);
     }
 
     // sharedptr1copy is destroyed, count is decremented
-    MBED_HOSTTEST_ASSERT(sharedptr1.use_count() == 1);
+    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
 
 
     /* Test 3: object is destroyed */
@@ -94,22 +92,36 @@ void app_start(int, char*[]) {
         globalFlag = true;
     }
 
-    MBED_HOSTTEST_ASSERT(globalFlag == false);
+    TEST_ASSERT_TRUE(globalFlag == false);
 
     /* Test 4: corner cases */
 
     // self assignment
-    MBED_HOSTTEST_ASSERT(sharedptr1.use_count() == 1);
+    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
     sharedptr1 = sharedptr1;
-    MBED_HOSTTEST_ASSERT(sharedptr1.use_count() == 1);
+    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
 
 
     /* Test 5: basic types */
     {
         SharedPointer<int> sharedptr3(new int);
         *sharedptr3 = 3;
-        MBED_HOSTTEST_ASSERT(*sharedptr3 == 3);
+        TEST_ASSERT_TRUE(*sharedptr3 == 3);
     }
+}
 
-    MBED_HOSTTEST_RESULT(true);
+static status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(2, "default_auto");
+
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+static Case cases[] = {
+    Case("SharedPointer  - test_shared_pointer", test_shared_pointer)
+};
+
+static Specification specification(test_setup, cases, greentea_test_teardown_handler);
+
+void app_start(int, char**) {
+    Harness::run(specification);
 }

--- a/test/SharedPointer/main.cpp
+++ b/test/SharedPointer/main.cpp
@@ -52,36 +52,36 @@ void test_shared_pointer() {
     SharedPointer<Number> sharedptr1(ptr1);
 
     // pointers match
-    TEST_ASSERT_TRUE(sharedptr1.get() == ptr1);
+    TEST_ASSERT_EQUAL(ptr1, sharedptr1.get());
 
     // counter match
-    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
+    TEST_ASSERT_EQUAL(1, sharedptr1.use_count());
 
     // dereferencing works
-    TEST_ASSERT_TRUE(sharedptr1->getNum() == 1);
+    TEST_ASSERT_EQUAL(1, sharedptr1->getNum());
 
     /* Test 2: copy pointer */
     {
         SharedPointer<Number> sharedptr1copy;
 
         // NULL pointer is NULL
-        TEST_ASSERT_TRUE(sharedptr1copy.get() == NULL);
-        TEST_ASSERT_TRUE(sharedptr1copy.use_count() == 0);
+        TEST_ASSERT_EQUAL(NULL, sharedptr1copy.get());
+        TEST_ASSERT_EQUAL(0, sharedptr1copy.use_count());
 
         // copy
         sharedptr1copy = sharedptr1;
 
         // raw pointer is consistent
-        TEST_ASSERT_TRUE(sharedptr1copy.get() == ptr1);
-        TEST_ASSERT_TRUE(sharedptr1copy.get() == sharedptr1.get());
+        TEST_ASSERT_EQUAL(ptr1, sharedptr1copy.get());
+        TEST_ASSERT_EQUAL(sharedptr1.get(), sharedptr1copy.get());
 
         // reference count is accurate
-        TEST_ASSERT_TRUE(sharedptr1.use_count() == 2);
-        TEST_ASSERT_TRUE(sharedptr1copy.use_count() == 2);
+        TEST_ASSERT_EQUAL(2, sharedptr1.use_count());
+        TEST_ASSERT_EQUAL(2, sharedptr1copy.use_count());
     }
 
     // sharedptr1copy is destroyed, count is decremented
-    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
+    TEST_ASSERT_EQUAL(1, sharedptr1.use_count());
 
 
     /* Test 3: object is destroyed */
@@ -92,21 +92,21 @@ void test_shared_pointer() {
         globalFlag = true;
     }
 
-    TEST_ASSERT_TRUE(globalFlag == false);
+    TEST_ASSERT_EQUAL(false, globalFlag);
 
     /* Test 4: corner cases */
 
     // self assignment
-    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
+    TEST_ASSERT_EQUAL(1, sharedptr1.use_count());
     sharedptr1 = sharedptr1;
-    TEST_ASSERT_TRUE(sharedptr1.use_count() == 1);
+    TEST_ASSERT_EQUAL(1, sharedptr1.use_count());
 
 
     /* Test 5: basic types */
     {
         SharedPointer<int> sharedptr3(new int);
         *sharedptr3 = 3;
-        TEST_ASSERT_TRUE(*sharedptr3 == 3);
+        TEST_ASSERT_EQUAL(3, *sharedptr3);
     }
 }
 

--- a/test/sbrk-mini/main.cpp
+++ b/test/sbrk-mini/main.cpp
@@ -17,7 +17,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 #include "core-util/sbrk.h"
 
 extern void * volatile mbed_sbrk_ptr;
@@ -28,7 +28,6 @@ extern volatile uintptr_t mbed_sbrk_diff;
     ((A) == (B) ? 1 : ((P) = false, (F) = __FILE__, (L) = __LINE__, 0))
 #define CHECK_NEQ(A,B,P,F,L)\
     ((A) != (B) ? 1 : ((P) = false, (F) = __FILE__, (L) = __LINE__, 0))
-
 
 bool runTest(int * line, const char ** file) {
     bool tests_pass = true;
@@ -90,7 +89,7 @@ class Test {
 public:
     Test():_pass(false), _line(0), _file(NULL)
     {
-        _pass = runTest(&_line, &_file);
+       _pass = runTest(&_line, &_file);
     }
     bool passed() {return _pass;}
     int line() {return _line;}
@@ -105,15 +104,12 @@ Test early_test;
 
 void app_start(int, char*[])
 {
-    MBED_HOSTTEST_TIMEOUT(10);
-    MBED_HOSTTEST_SELECT(default);
-    MBED_HOSTTEST_DESCRIPTION(sbrk mini test);
-    MBED_HOSTTEST_START("SBRK_MINI_TEST");
+    GREENTEA_SETUP(10, "default_auto");
 
     if (!early_test.passed()) {
         printf("MBED: Failed at %s:%d\r\n", early_test.file(), early_test.line());
     }
 
-    MBED_HOSTTEST_RESULT(early_test.passed());
+    GREENTEA_TESTSUITE_RESULT(early_test.passed());
     return;
 }

--- a/test/uninitialized/main.cpp
+++ b/test/uninitialized/main.cpp
@@ -16,7 +16,8 @@
  */
 #include <stdint.h>
 #include "cmsis-core/core_generic.h"
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
+#include "mbed-drivers/mbed.h"
 #include "core-util/uninitialized.h"
 
 #define TEST_C_INIT      0xDEADBEEFUL
@@ -29,16 +30,10 @@ void app_start(int, char*[])
     if (g_state == TEST_C_INIT) {
         /* First run: Check that the g_state does *not* hold the initialized
          * data. */
-        MBED_HOSTTEST_TIMEOUT(5);
-        MBED_HOSTTEST_SELECT(default);
-        MBED_HOSTTEST_DESCRIPTION(uninitialized section);
-        MBED_HOSTTEST_START("UNINITIALIZED_SECTION_TEST");
-        MBED_HOSTTEST_RESULT(false);
+        GREENTEA_SETUP(5, "default_auto");
+        GREENTEA_TESTSUITE_RESULT(false);
     } else if (g_state != TEST_MANUAL_INIT) {
-        MBED_HOSTTEST_TIMEOUT(5);
-        MBED_HOSTTEST_SELECT(default);
-        MBED_HOSTTEST_DESCRIPTION(uninitialized section);
-        MBED_HOSTTEST_START("UNINITIALIZED_SECTION_TEST");
+        GREENTEA_SETUP(5, "default_auto");
 
         /* First or subsequent runs: If this is the first run, initialize the
          * state and reset. If this code is run again after the first run it
@@ -50,7 +45,7 @@ void app_start(int, char*[])
         /* Second run: The data was correctly initialized and kept across a
          * system reset. */
         g_state = 0;
-        MBED_HOSTTEST_RESULT(true);
+        GREENTEA_TESTSUITE_RESULT(true);
     }
 
     return;


### PR DESCRIPTION
Test ```core-util-test-uninitialized``` is unstable. Still work to do.
Test results from ```$mbedgt -VS --report-junit JUnit.xml```:
```
mbedgt: test suite report:
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| target        | platform_name | test suite                             | result | elapsed_time (sec) | copy_method |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | core-util-test-array                   | OK     | 11.1               | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | OK     | 12.34              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | OK     | 17.69              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-extendablepoolallocator | OK     | 10.84              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-functionpointer         | OK     | 11.65              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-poolallocator           | OK     | 10.76              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-sbrk-mini               | OK     | 10.43              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-sharedpointer           | OK     | 11.06              | shell       |
| frdm-k64f-gcc | K64F          | core-util-test-uninitialized           | ERROR  | 9.94               | shell       |
+---------------+---------------+----------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 8 OK / 1 ERROR
mbedgt: test case report:
+---------------+---------------+----------------------------------------+-----------------------------------------------------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite                             | test case                                                 | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+----------------------------------------+-----------------------------------------------------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | core-util-test-poolallocator           | PoolAllocator  - test_pool_allocator                      | 1      | 0      | OK     | 0.08               |
| frdm-k64f-gcc | K64F          | core-util-test-sharedpointer           | SharedPointer  - test_shared_pointer                      | 1      | 0      | OK     | 0.17               |
| frdm-k64f-gcc | K64F          | core-util-test-array                   | Array  - test with complex data                           | 1      | 0      | OK     | 0.08               |
| frdm-k64f-gcc | K64F          | core-util-test-array                   | Array  - test with plain old data                         | 1      | 0      | OK     | 0.08               |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | BinaryHeap  - test_max_heap_non_pod                       | 1      | 0      | OK     | 0.17               |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | BinaryHeap  - test_max_heap_pod                           | 1      | 0      | OK     | 0.15               |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | BinaryHeap  - test_min_heap_non_pod                       | 1      | 0      | OK     | 0.17               |
| frdm-k64f-gcc | K64F          | core-util-test-binaryheap              | BinaryHeap  - test_min_heap_pod                           | 1      | 0      | OK     | 0.16               |
| frdm-k64f-gcc | K64F          | core-util-test-functionpointer         | FunctionPointer  - test_function_pointer                  | 1      | 0      | OK     | 0.81               |
| frdm-k64f-gcc | K64F          | core-util-test-extendablepoolallocator | ExtendablePoolAllocator  - test_extendable_pool_allocator | 1      | 0      | OK     | 0.1                |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | EventHandler  - test_array_of_events                      | 1      | 0      | OK     | 0.5                |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | EventHandler  - test_class_funcs_tca                      | 1      | 0      | OK     | 2.4                |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | EventHandler  - test_event_assignment_and_swap            | 1      | 0      | OK     | 0.82               |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | EventHandler  - test_funcs_nontca                         | 1      | 0      | OK     | 1.03               |
| frdm-k64f-gcc | K64F          | core-util-test-eventhandler            | EventHandler  - test_standalone_funcs                     | 1      | 0      | OK     | 1.1                |
+---------------+---------------+----------------------------------------+-----------------------------------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 15 OK
mbedgt: completed in 107.57 sec
mbedgt: exited with code 1
```
```
$yt ls
core-util 1.3.0
|_ ualloc 1.0.3
| \_ dlmalloc 1.0.0 yotta_modules\dlmalloc
|_ cmsis-core 1.1.2
| \_ cmsis-core-freescale 1.0.0 yotta_modules\cmsis-core-freescale
|   \_ cmsis-core-k64f 1.0.0 yotta_modules\cmsis-core-k64f
|_ mbed-drivers 0.12.1
| |_ mbed-hal 1.2.2 yotta_modules\mbed-hal
| | \_ mbed-hal-freescale 1.0.0 yotta_modules\mbed-hal-freescale
| |   \_ mbed-hal-ksdk-mcu 1.0.8 yotta_modules\mbed-hal-ksdk-mcu
| |     |_ uvisor-lib 1.0.12 yotta_modules\uvisor-lib
| |     \_ mbed-hal-k64f 1.1.0 yotta_modules\mbed-hal-k64f
| |       \_ mbed-hal-frdm-k64f 1.0.2 yotta_modules\mbed-hal-frdm-k64f
| |_ minar 1.0.4 yotta_modules\minar
| | \_ minar-platform 1.0.0 yotta_modules\minar-platform
| |   \_ minar-platform-mbed 1.1.2 yotta_modules\minar-platform-mbed
| \_ compiler-polyfill 1.2.1 yotta_modules\compiler-polyfill
|_ greentea-client 0.1.4
|_ utest 1.9.1 yotta_modules\utest -> C:\Users\stefan.gutmann@arm.com\Documents\GitHub\Demo\utest
\_ unity 2.1.0
```