### PR TITLE
Fix issue#54

### DIFF
--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -21,13 +21,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// [TODO] this should probably be 8, but at the moment our allocators are
-// aligned at 4 bytes
 // [TODO] where should the system allocator alignment be defined?
-#define MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN       4
+#define MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN       8
 // [TODO] currently, the requested alignment (in the PoolAllocator constructor) must be
 // less than or equal to MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN, which effectively limits it to
-// 4 bytes for now
+// 8 bytes for now
 
 namespace mbed {
 namespace util {

--- a/core-util/PoolAllocator.h
+++ b/core-util/PoolAllocator.h
@@ -21,11 +21,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// [TODO] where should the system allocator alignment be defined?
-#define MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN       8
-// [TODO] currently, the requested alignment (in the PoolAllocator constructor) must be
-// less than or equal to MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN, which effectively limits it to
-// 8 bytes for now
+#ifndef YOTTA_CFG_CORE_UTIL_POOL_ALLOC_DEFAULT_ALIGN
+#define YOTTA_CFG_CORE_UTIL_POOL_ALLOC_DEFAULT_ALIGN 8
+#endif 
+
+#define MBED_UTIL_POOL_ALLOC_DEFAULT_ALIGN YOTTA_CFG_CORE_UTIL_POOL_ALLOC_DEFAULT_ALIGN
 
 namespace mbed {
 namespace util {

--- a/core-util/sbrk.h
+++ b/core-util/sbrk.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifndef SBRK_ALIGN
-#define SBRK_ALIGN 4U
+#define SBRK_ALIGN 8U
 #endif
 #if (SBRK_ALIGN & (SBRK_ALIGN-1))
 #error SBRK_ALIGN must be a power of 2
@@ -64,7 +64,7 @@
 #endif
 
 #ifndef KRBS_ALIGN
-#define KRBS_ALIGN 4U
+#define KRBS_ALIGN 8U
 #endif
 #if (KRBS_ALIGN & (KRBS_ALIGN-1))
 #error KRBS_ALIGN must be a power of 2

--- a/test/sbrk-mini/main.cpp
+++ b/test/sbrk-mini/main.cpp
@@ -42,15 +42,15 @@ bool runTest(int * line, const char ** file) {
         }
 
         ptr = (uintptr_t) mbed_sbrk(TEST_SMALL);
-        if(!CHECK_EQ(ptr, init_sbrk_ptr + TEST_SMALL, tests_pass, *file, *line)) {
+        if(!CHECK_EQ(ptr, init_sbrk_ptr + SBRK_ALIGN, tests_pass, *file, *line)) {
             break;
         }
 
         ptr = (uintptr_t) mbed_krbs(TEST_SMALL);
-        if(!CHECK_EQ(ptr, (uintptr_t) &__mbed_krbs_start - TEST_SMALL, tests_pass, *file, *line)) {
+        if(!CHECK_EQ(ptr, (uintptr_t) &__mbed_krbs_start - KRBS_ALIGN, tests_pass, *file, *line)) {
             break;
         }
-        if(!CHECK_EQ(mbed_sbrk_diff, (ptrdiff_t)&__heap_size - 3*TEST_SMALL - (init_sbrk_ptr - (uintptr_t)&__mbed_sbrk_start), tests_pass, *file, *line)) {
+        if(!CHECK_EQ(mbed_sbrk_diff, (ptrdiff_t)&__heap_size - 3*SBRK_ALIGN - (init_sbrk_ptr - (uintptr_t)&__mbed_sbrk_start), tests_pass, *file, *line)) {
             break;
         }
 
@@ -58,13 +58,13 @@ bool runTest(int * line, const char ** file) {
         // Test small increments
         for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
             ptr = (uintptr_t) mbed_krbs(i);
-            if(!CHECK_EQ(0, ptr & (TEST_SMALL - 1), tests_pass, *file, *line)) {
+            if(!CHECK_EQ(0, ptr & (KRBS_ALIGN - 1), tests_pass, *file, *line)) {
                 break;
             }
         }
         for (unsigned int i = 0; tests_pass && i < TEST_SMALL; i++) {
             ptr = (uintptr_t) mbed_sbrk(i);
-            if(!CHECK_EQ(0, (uintptr_t) mbed_sbrk_ptr & (TEST_SMALL - 1), tests_pass, *file, *line)) {
+            if(!CHECK_EQ(0, (uintptr_t) mbed_sbrk_ptr & (SBRK_ALIGN - 1), tests_pass, *file, *line)) {
                 break;
             }
         }


### PR DESCRIPTION
```
+---------------+---------------+--------------------------+--------+--------------------+-------------+
| target        | platform_name | test                     | result | elapsed_time (sec) | copy_method |
+---------------+---------------+--------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | core-util-test-sbrk-mini | OK     | 2.39               | shell       |
+---------------+---------------+--------------------------+--------+--------------------+-------------+
```

This change-set shall be merged after #83, as that one fixes the internal tests. Then this one should not cause any failure.

I would like to eliminate those 2 TODOs in PoolAllocator. I can just remove them, any suggestions?

@bremoran @mjs-arm @bogdanm 