### PR TITLE
Module - mbed-drivers dep update to v1

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   "targetDependencies": {
     "mbed": {
       "cmsis-core": "^1.0.0",
-      "mbed-drivers": "~0.12.0"
+      "mbed-drivers": ">=0.12.0,<2.0.0"
     }
   },
   "scripts": {


### PR DESCRIPTION
Fixes "error: mbed-drivers does not meet specification ~0.12.0 required by core-util" reported by yotta for apps.

mbed-drivers currently depend on this module as ^1.0.0

@bogdanm @bremoran 