### PR TITLE
Relax dependency on mbed-drivers

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,7 +24,7 @@
   "targetDependencies": {
     "mbed": {
       "cmsis-core": "^1.0.0",
-      "mbed-drivers": ">=0.12.0,<2.0.0"
+      "mbed-drivers": ">=0.11.0,<2.0.0"
     }
   },
   "scripts": {


### PR DESCRIPTION
core-util only depends on mbed-interface.h. mbed-interface.h has not had a meaningful update since 0.11.0, so the requirements of core-util should reflect that with a wider compatible version specifier.

cc @bogdanm @mjs-arm @0xc0170 @sbutcher-arm 