### PR TITLE
atomic_ops.cpp: guard inclusion of cmsis.h with TARGET_LIKE_MBED

### DIFF
--- a/source/atomic_ops.cpp
+++ b/source/atomic_ops.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "core-util/atomic_ops.h"
+#if defined(TARGET_LIKE_MBED)
 #include "cmsis.h"
+#endif
 
 namespace mbed {
 namespace util {


### PR DESCRIPTION
otherwise atomic_ops.cpp won't build on POSIX.